### PR TITLE
Ensure that DB names only contain supported characters to prevent fail…

### DIFF
--- a/playbooks/vars/containerized-webapp.yml
+++ b/playbooks/vars/containerized-webapp.yml
@@ -3,7 +3,7 @@
 azure_resource_group: 'jt-rg'
 
 # PostgreSQL Server variables
-azure_postgresql_name: "{{ azure_resource_group }}-dbserver"
+azure_postgresql_name: "{{ azure_resource_group | regex_replace('[^a-zA-Z0-9]','-') }}-dbserver"
 azure_postgresql_admin_username: "ansible"
 azure_postgresql_admin_password: "4fB5In3ueO7,"
 azure_postgresql_database_instances:


### PR DESCRIPTION
The deployment will fail when certain supported characters in resource name are used as a part of the database name.  This will replace unsupported chars with a dash in the db name to prevent those errors.