### PR TITLE
Move 'azure_resource_group' out of set_facts 

### DIFF
--- a/molecule/default/tasks/load_balancer.yml
+++ b/molecule/default/tasks/load_balancer.yml
@@ -7,7 +7,6 @@
 
 - name: Define region
   set_fact:
-    azure_resource_group: "{{ resource_group }}"
     azure_region: 'canadacentral'
 
 - name: Test load balancer role
@@ -28,12 +27,13 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -43,7 +43,7 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Assert that load balancer was successfully created with defaults
@@ -51,7 +51,7 @@
             that:
               - lb_info.ansible_info.azure_loadbalancers | length == 1
               - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].name == 'default'
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ azure_resource_group }}-lb-public-ip')
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ resource_group }}-lb-public-ip')
               - lb_info.ansible_info.azure_loadbalancers[0].properties.backendAddressPools[0].name == 'default'
               - lb_info.ansible_info.azure_loadbalancers[0].properties.loadBalancingRules | length == 0
               - lb_info.ansible_info.azure_loadbalancers[0].properties.probes | length == 0
@@ -63,12 +63,13 @@
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert resource group still exists
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - assert:
@@ -77,7 +78,7 @@
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -91,13 +92,14 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
               public_ip_name: 'testinput'
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -107,7 +109,7 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Assert that load balancer was successfully created with public IP input
@@ -123,12 +125,13 @@
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -142,13 +145,14 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              domain_name: "{{ azure_resource_group  | replace('_', '-')  }}-{{ azure_region  | replace('_', '-')  }}-lb"
-              name: "{{ azure_resource_group }}-lb"
+              domain_name: "{{ resource_group  | replace('_', '-')  }}-{{ azure_region  | replace('_', '-')  }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -158,7 +162,7 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Get lb's public ip info
@@ -170,9 +174,9 @@
           assert:
             that:
               - lb_info.ansible_info.azure_loadbalancers | length == 1
-              - pip.response[0].properties.dnsSettings.fqdn == '{{ azure_resource_group  | replace('_', '-')  }}-{{ azure_region  | replace('_', '-')  }}-lb.canadacentral.cloudapp.azure.com'
+              - pip.response[0].properties.dnsSettings.fqdn == '{{ resource_group  | replace('_', '-')  }}-{{ azure_region  | replace('_', '-')  }}-lb.canadacentral.cloudapp.azure.com'
               - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].name == 'default'
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ azure_resource_group }}-lb-public-ip')
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ resource_group }}-lb-public-ip')
               - lb_info.ansible_info.azure_loadbalancers[0].properties.backendAddressPools[0].name == 'default'
 
         - name: Delete load balancer
@@ -180,12 +184,13 @@
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -199,15 +204,16 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
               frontend_ip_configurations:
-                - name: "{{ azure_resource_group }}-frontend"
-                  public_ip_address: "{{ azure_resource_group }}-lb-public-ip"
-              name: "{{ azure_resource_group }}-lb"
+                - name: "{{ resource_group }}-frontend"
+                  public_ip_address: "{{ resource_group }}-lb-public-ip"
+              name: "{{ resource_group }}-lb"
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -217,7 +223,7 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Assert that load balancer was successfully created with input frontend ip configurations
@@ -225,20 +231,21 @@
             that:
               - lb_info.ansible_info.azure_loadbalancers | length == 1
               - lb_info.ansible_info.azure_loadbalancers[0].properties.backendAddressPools[0].name == 'default'
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].name == '{{ azure_resource_group }}-frontend'
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ azure_resource_group }}-lb-public-ip')
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].name == '{{ resource_group }}-frontend'
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ resource_group }}-lb-public-ip')
 
         - name: Delete load balancer
           include_role:
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -252,14 +259,15 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
               backend_address_pools:
-                - name: "{{ azure_resource_group }}-vm-pool"
-              name: "{{ azure_resource_group }}-lb"
+                - name: "{{ resource_group }}-vm-pool"
+              name: "{{ resource_group }}-lb"
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -269,28 +277,29 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Assert that load balancer was successfully created with input backend address pool
           assert:
             that:
               - lb_info.ansible_info.azure_loadbalancers | length == 1
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.backendAddressPools[0].name == '{{ azure_resource_group }}-vm-pool'
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.backendAddressPools[0].name == '{{ resource_group }}-vm-pool'
               - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].name == 'default'
-              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ azure_resource_group }}-lb-public-ip')
+              - lb_info.ansible_info.azure_loadbalancers[0].properties.frontendIPConfigurations[0].properties.publicIPAddress.id is search('{{ resource_group }}-lb-public-ip')
 
         - name: Delete load balancer
           include_role:
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -304,8 +313,9 @@
             name: load_balancer
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
               probes:
                 - name: lb-probe
                   port: 5000
@@ -323,7 +333,7 @@
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -333,7 +343,7 @@
 
         - name: Get lb info
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - name: Assert that load balancer was successfully created with input custom probes, rules, tags, and sku
@@ -350,12 +360,13 @@
             name: load_balancer
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_load_balancer:
-              name: "{{ azure_resource_group }}-lb"
+              name: "{{ resource_group }}-lb"
 
         - name: Assert that load balancer was deleted
           azure_rm_loadbalancer_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: lb_info
 
         - assert:
@@ -365,7 +376,7 @@
   always:
     - name: Delete resource group
       azure_rm_resourcegroup:
-        name: "{{ azure_resource_group }}"
+        name: "{{ resource_group }}"
         state: absent
         force_delete_nonempty: yes
       ignore_errors: yes

--- a/molecule/default/tasks/network_interface.yml
+++ b/molecule/default/tasks/network_interface.yml
@@ -18,7 +18,7 @@
 
     - name: Set facts
       set_fact:
-        azure_resource_group: "test-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
+        resource_group: "test_{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
         azure_region: canadacentral
         azure_tags:
           cloud.azure_roles: network_interface
@@ -30,17 +30,18 @@
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
-              name: "{{ azure_resource_group }}-nic"
+              name: "{{ resource_group }}-nic"
       rescue:
         - name: Assert correct error message
           fail:
             msg: "Task failed with incorrect error message"
-          when: ansible_failed_result.msg is not match("Resource group '{{ azure_resource_group }}' does not exist")
+          when: ansible_failed_result.msg is not match("Resource group '{{ resource_group }}' does not exist")
 
         - name: Create resource group
           azure_rm_resourcegroup:
-            name: "{{ azure_resource_group }}"
+            name: "{{ resource_group }}"
             location: "{{ azure_region }}"
 
     - name: Attempt to create nic with no name - should fail
@@ -50,6 +51,7 @@
             name: network_interface
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
       rescue:
         - name: Assert correct error message
           fail:
@@ -63,8 +65,9 @@
             name: network_interface
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
-              name: "{{ azure_resource_group }}-nic"
+              name: "{{ resource_group }}-nic"
       rescue:
         - name: Assert correct error message
           fail:
@@ -78,9 +81,10 @@
             name: network_interface
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
-              name: "{{ azure_resource_group }}-nic"
-              vnet_name: "{{ azure_resource_group }}-vnet"
+              name: "{{ resource_group }}-nic"
+              vnet_name: "{{ resource_group }}-vnet"
       rescue:
         - name: Assert correct error message
           fail:
@@ -89,17 +93,17 @@
 
     - name: Set networking facts
       set_fact:
-        nic_name: "{{ azure_resource_group }}-nic"
+        nic_name: "{{ resource_group }}-nic"
         vnet:
-          name: "{{ azure_resource_group }}-vnet"
+          name: "{{ resource_group }}-vnet"
           address_prefixes_cidr:
             - 10.16.0.0/16
-          resource_group: "{{ azure_resource_group }}"
+          resource_group: "{{ resource_group }}"
         subnet:
-          name: "{{ azure_resource_group }}-subnet"
+          name: "{{ resource_group }}-subnet"
           address_prefix_cidr: 10.16.0.0/24
-          resource_group: "{{ azure_resource_group }}"
-          virtual_network_name: "{{ azure_resource_group }}-vnet"
+          resource_group: "{{ resource_group }}"
+          virtual_network_name: "{{ resource_group }}-vnet"
 
     - name: Attempt to create nic with nonexistent virtual network - should fail
       block:
@@ -108,6 +112,7 @@
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
               vnet_name: "{{ vnet.name }}"
@@ -128,6 +133,7 @@
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
               vnet_name: "{{ vnet.name }}"
@@ -148,6 +154,7 @@
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
               vnet_name: "{{ vnet.name }}"
@@ -155,7 +162,7 @@
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: nic_info
 
         - name: Assert that network interface was successfully created
@@ -165,85 +172,88 @@
 
         - name: Create public ip
           azure_rm_publicipaddress:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-pip"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-pip"
 
         - name: Update nic with public ip
           include_role:
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
               vnet_name: "{{ vnet.name }}"
               subnet_name: "{{ subnet.name }}"
               ip_configurations:
                 - name: ipconf1
-                  public_ip_address_name: "{{ azure_resource_group }}-pip"
+                  public_ip_address_name: "{{ resource_group }}-pip"
                   primary: True
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: nic_info
 
         - name: Assert that public ip is attached to nic
           assert:
             that:
               - nic_info.networkinterfaces | length == 1
-              - nic_info.networkinterfaces[0].ip_configurations[0].public_ip_address is search("{{ azure_resource_group }}-pip")
+              - nic_info.networkinterfaces[0].ip_configurations[0].public_ip_address is search("{{ resource_group }}-pip")
 
         - name: Test security group parameters
           block:
             - name: Create security group for nic
               azure_rm_securitygroup:
-                resource_group: "{{ azure_resource_group }}"
-                name: "{{ azure_resource_group }}-sg"
+                resource_group: "{{ resource_group }}"
+                name: "{{ resource_group }}-sg"
 
             - name: Update nic with security group
               include_role:
                 name: network_interface
               vars:
                 operation: "create"
+                azure_resource_group: "{{ resource_group }}"
                 azure_network_interface:
                   name: "{{ nic_name }}"
                   vnet_name: "{{ vnet.name }}"
                   subnet_name: "{{ subnet.name }}"
                   ip_configurations:
                     - name: ipconf1
-                      public_ip_address_name: "{{ azure_resource_group }}-pip"
+                      public_ip_address_name: "{{ resource_group }}-pip"
                       primary: True
-                  security_group_name: "{{ azure_resource_group }}-sg"
+                  security_group_name: "{{ resource_group }}-sg"
 
             - name: Get nic info
               azure_rm_networkinterface_info:
-                resource_group: '{{ azure_resource_group }}'
+                resource_group: '{{ resource_group }}'
               register: nic_info
 
             - name: Assert that security group is attached to nic
               assert:
                 that:
                   - nic_info.networkinterfaces | length == 1
-                  - nic_info.networkinterfaces[0].security_group is search("{{ azure_resource_group }}-sg")
+                  - nic_info.networkinterfaces[0].security_group is search("{{ resource_group }}-sg")
 
             - name: Update nic with no default security group
               include_role:
                 name: network_interface
               vars:
                 operation: "create"
+                azure_resource_group: "{{ resource_group }}"
                 azure_network_interface:
                   name: "{{ nic_name }}"
                   vnet_name: "{{ vnet.name }}"
                   subnet_name: "{{ subnet.name }}"
                   ip_configurations:
                     - name: ipconf1
-                      public_ip_address_name: "{{ azure_resource_group }}-pip"
+                      public_ip_address_name: "{{ resource_group }}-pip"
                       primary: True
                   create_with_security_group: no
 
             - name: Get nic info
               azure_rm_networkinterface_info:
-                resource_group: '{{ azure_resource_group }}'
+                resource_group: '{{ resource_group }}'
               register: nic_info
 
             - name: Assert that security group is removed
@@ -259,15 +269,16 @@
                 name: network_interface
               vars:
                 operation: "create"
+                azure_resource_group: "{{ resource_group }}"
                 azure_network_interface:
                   name: "{{ nic_name }}"
                   vnet_name: "{{ vnet.name }}"
                   subnet_name: "{{ subnet.name }}"
                   ip_configurations:
                     - name: ipconf1
-                      public_ip_address_name: "{{ azure_resource_group }}-pip"
+                      public_ip_address_name: "{{ resource_group }}-pip"
                       primary: True
-                  security_group_name: "{{ azure_resource_group }}-sg"
+                  security_group_name: "{{ resource_group }}-sg"
                   os_type: Windows
                   enable_accelerated_networking: yes
                   ip_forwarding: yes
@@ -276,7 +287,7 @@
 
             - name: Get nic info
               azure_rm_networkinterface_info:
-                resource_group: '{{ azure_resource_group }}'
+                resource_group: '{{ resource_group }}'
               register: nic_info
 
             - name: Assert that extra params were set properly
@@ -294,17 +305,18 @@
             name: network_interface
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: nic_info
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: sg_info
 
         - name: Assert that network interface was deleted and its default security group does not exist
@@ -318,6 +330,7 @@
             name: network_interface
           vars:
             operation: "create"
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
               vnet_name: "{{ vnet.name }}"
@@ -325,12 +338,12 @@
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: nic_info
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: sg_info
 
         - name: Assert that network interface was created with its default security group
@@ -344,17 +357,18 @@
             name: network_interface
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_network_interface:
               name: "{{ nic_name }}"
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: nic_info
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: sg_info
 
         - name: Assert that network interface and its security group were deleted
@@ -366,7 +380,7 @@
   always:
     - name: Delete resource group
       azure_rm_resourcegroup:
-        name: "{{ azure_resource_group }}"
+        name: "{{ resource_group }}"
         state: absent
         force_delete_nonempty: yes
       ignore_errors: yes

--- a/molecule/default/tasks/security_group.yml
+++ b/molecule/default/tasks/security_group.yml
@@ -17,7 +17,7 @@
 
     - name: Set facts
       set_fact:
-        azure_resource_group: "test-sg-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
+        resource_group: "test-sg-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
         azure_region: 'canadacentral'
         azure_tags:
           cloud.azure_roles: security_group
@@ -29,6 +29,8 @@
             name: security_group
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
+
       rescue:
         - name: Assert correct error message
           fail:
@@ -37,7 +39,7 @@
 
         - name: Set security group name
           set_fact:
-            sg_name: "{{ azure_resource_group }}-sg"
+            sg_name: "{{ resource_group }}-sg"
 
     - name: Test valid creation of security group
       block:
@@ -46,12 +48,13 @@
             name: security_group
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -64,7 +67,7 @@
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: '{{ azure_resource_group }}'
+            name: '{{ resource_group }}'
           register: rg
 
         - name: Assert that resource group was created
@@ -78,6 +81,7 @@
           include_role:
             name: security_group
           vars:
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
               rules:
@@ -106,7 +110,7 @@
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -120,32 +124,32 @@
 
         - name: Create VNet
           azure_rm_virtualnetwork:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-vnet"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-vnet"
             address_prefixes_cidr:
               - '10.16.0.0/16'
               - '172.100.0.0/16'
 
         - name: Create Subnet
           azure_rm_subnet:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-subnet-00"
-            virtual_network_name: "{{ azure_resource_group }}-vnet"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-subnet-00"
+            virtual_network_name: "{{ resource_group }}-vnet"
             address_prefix_cidr: '10.16.0.0/24'
             security_group: "{{ sg_name }}"
 
         - name: Create Second Subnet
           azure_rm_subnet:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-subnet-01"
-            virtual_network_name: "{{ azure_resource_group }}-vnet"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-subnet-01"
+            virtual_network_name: "{{ resource_group }}-vnet"
             address_prefix_cidr: '172.100.0.0/24'
             security_group: "{{ sg_name }}"
 
         - name: Create a public ip
           azure_rm_publicipaddress:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-pip"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-pip"
             sku: Standard
             allocation_method: Static
           register: ip
@@ -156,30 +160,30 @@
 
         - name: Create Network Interface with public ip
           azure_rm_networkinterface:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-nic"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-nic"
             security_group: "{{ sg_name }}"
             ip_configurations:
               - name: ipconf0
-                public_ip_address_name: "{{ azure_resource_group }}-pip"
-            virtual_network: "{{ azure_resource_group }}-vnet"
-            subnet_name: "{{ azure_resource_group }}-subnet-00"
+                public_ip_address_name: "{{ resource_group }}-pip"
+            virtual_network: "{{ resource_group }}-vnet"
+            subnet_name: "{{ resource_group }}-subnet-00"
 
         - name: Create Another Network Interface with no public ip
           azure_rm_networkinterface:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-nic2"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-nic2"
             security_group: "{{ sg_name }}"
             ip_configurations:
               - name: ipconf1
-            virtual_network: "{{ azure_resource_group }}-vnet"
-            subnet_name: "{{ azure_resource_group }}-subnet-00"
+            virtual_network: "{{ resource_group }}-vnet"
+            subnet_name: "{{ resource_group }}-subnet-00"
 
         - name: Create a VM
           azure_rm_virtualmachine:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-vm"
-            network_interfaces: "{{ azure_resource_group }}-nic"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-vm"
+            network_interfaces: "{{ resource_group }}-nic"
             admin_username: 'testuser'
             admin_password: '4fB5In3ueO7,'
             image:
@@ -191,8 +195,8 @@
 
         - name: Get public ip info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-pip"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-pip"
           register: pip_info
 
         - name: Test SSH access to VM
@@ -205,6 +209,7 @@
           include_role:
             name: security_group
           vars:
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
               rules_to_remove:
@@ -212,7 +217,7 @@
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -228,6 +233,7 @@
           include_role:
             name: security_group
           vars:
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
               rules_to_remove:
@@ -235,7 +241,7 @@
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -251,6 +257,7 @@
           include_role:
             name: security_group
           vars:
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
               rules_to_remove:
@@ -258,7 +265,7 @@
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -271,7 +278,7 @@
       block:
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -286,12 +293,13 @@
             name: security_group
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -307,12 +315,13 @@
             name: security_group
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -326,12 +335,13 @@
             name: security_group
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_security_group:
               name: "{{ sg_name }}"
 
         - name: Get security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ sg_name }}"
           register: sg_info
 
@@ -343,7 +353,7 @@
   always:
     - name: Delete resource group and all its content
       azure_rm_resourcegroup:
-        name: "{{ azure_resource_group }}"
+        name: "{{ resource_group }}"
         state: absent
         force_delete_nonempty: yes
       ignore_errors: yes

--- a/molecule/default/tasks/virtual_machine.yml
+++ b/molecule/default/tasks/virtual_machine.yml
@@ -18,7 +18,7 @@
 
     - name: Set facts
       set_fact:
-        azure_resource_group: "test-vm-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
+        resource_group: "test-vm-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
         azure_region: canadacentral
         azure_tags:
           cloud.azure_roles: virtual_machine
@@ -30,8 +30,9 @@
             name: virtual_machine
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
             remove_on_absent: 'invalid'
       rescue:
         - name: Assert correct error message
@@ -46,13 +47,14 @@
             name: virtual_machine
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
       rescue:
         - name: Assert correct error message
           fail:
             msg: "Task failed with incorrect error message"
-          when: ansible_failed_result.msg is not match("Resource group {{ azure_resource_group }} does not exist")
+          when: ansible_failed_result.msg is not match("Resource group {{ resource_group }} does not exist")
 
     - name: Attempt to create VM with no name - should fail
       block:
@@ -61,6 +63,7 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
       rescue:
         - name: Assert correct error message
           fail:
@@ -74,8 +77,9 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
       rescue:
         - name: Assert correct error message
           fail:
@@ -89,8 +93,9 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
               admin_username: 'admin'
       rescue:
         - name: Assert correct error message
@@ -105,8 +110,9 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
               admin_username: 'admin'
               size: 'Standard_DS1_v2'
       rescue:
@@ -122,8 +128,9 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
               admin_username: 'azureuser'
               admin_password: '4fB5In3ueO7,'
               image:
@@ -140,29 +147,29 @@
 
         - name: Set facts
           set_fact:
-            vm_name: "{{ azure_resource_group }}-vm"
-            as_name: "{{ azure_resource_group }}-as"
-            nic_name: "{{ azure_resource_group }}-nic"
+            vm_name: "{{ resource_group }}-vm"
+            as_name: "{{ resource_group }}-as"
+            nic_name: "{{ resource_group }}-nic"
             vnet:
-              name: "{{ azure_resource_group }}-vnet"
+              name: "{{ resource_group }}-vnet"
               address_prefixes_cidr:
                 - 10.16.0.0/16
-              resource_group: "{{ azure_resource_group }}"
+              resource_group: "{{ resource_group }}"
             subnet:
-              name: "{{ azure_resource_group }}-subnet"
+              name: "{{ resource_group }}-subnet"
               address_prefix_cidr: 10.16.0.0/24
-              resource_group: "{{ azure_resource_group }}"
-              virtual_network_name: "{{ azure_resource_group }}-vnet"
+              resource_group: "{{ resource_group }}"
+              virtual_network_name: "{{ resource_group }}-vnet"
             vnet2:
-              name: "{{ azure_resource_group }}-vnet2"
+              name: "{{ resource_group }}-vnet2"
               address_prefixes_cidr:
                 - 10.16.0.0/16
-              resource_group: "{{ azure_resource_group }}"
+              resource_group: "{{ resource_group }}"
             subnet2:
-              name: "{{ azure_resource_group }}-subnet2"
+              name: "{{ resource_group }}-subnet2"
               address_prefix_cidr: 10.16.0.0/24
-              resource_group: "{{ azure_resource_group }}"
-              virtual_network_name: "{{ azure_resource_group }}-vnet2"
+              resource_group: "{{ resource_group }}"
+              virtual_network_name: "{{ resource_group }}-vnet2"
 
         - name: Create virtual network
           azure_rm_virtualnetwork: "{{ vnet }}"
@@ -177,6 +184,7 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_availability_set:
               name: "{{ as_name }}"
               platform_update_domain_count: 5
@@ -196,7 +204,7 @@
 
         - name: Get availability set info
           azure_rm_availabilityset_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ as_name }}"
           register: as_info
 
@@ -217,6 +225,7 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
               admin_username: 'azureuser'
@@ -232,7 +241,7 @@
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: "{{ azure_resource_group }}"
+            name: "{{ resource_group }}"
           register: rg
 
         - name: Assert that resource group was created
@@ -242,13 +251,13 @@
 
         - name: Get vm info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: vm_info
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: nic_info
 
@@ -264,16 +273,16 @@
       block:
         - name: Create load balancers public ip
           azure_rm_publicipaddress:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-lb-public-ip"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-lb-public-ip"
 
         - name: Create load balancer
           azure_rm_loadbalancer:
-            resource_group: "{{ azure_resource_group }}"
-            name: "{{ azure_resource_group }}-lb"
+            resource_group: "{{ resource_group }}"
+            name: "{{ resource_group }}-lb"
             frontend_ip_configurations: "{{ azure_load_balancer.frontend_ip_configurations |
                                     default([{ 'name': 'default',
-                                               'public_ip_address': azure_load_balancer.public_ip_name | default(azure_resource_group + '-lb-public-ip') }]) }}"
+                                               'public_ip_address': azure_load_balancer.public_ip_name | default(resource_group + '-lb-public-ip') }]) }}"
             backend_address_pools: [{ 'name': 'default' }]
 
         - name: Create virtual machine with default nic with lb
@@ -281,6 +290,7 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
               admin_username: 'azureuser'
@@ -293,11 +303,11 @@
               size: 'Standard_DS1_v2'
               load_balancer_backend_address_pools:
                 - name: 'default'
-                  load_balancer: "{{ azure_resource_group }}-lb"
+                  load_balancer: "{{ resource_group }}-lb"
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: "{{ azure_resource_group }}"
+            name: "{{ resource_group }}"
           register: rg
 
         - name: Assert that resource group was created
@@ -307,13 +317,13 @@
 
         - name: Get vm info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: vm_info
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: nic_info
 
@@ -323,7 +333,7 @@
               - vm_info.vms | length == 1
               - vm_name == vm_info.vms[0].network_interface_names[0]
               - nic_info.networkinterfaces[0].security_group is search("{{ vm_name }}")
-              - nic_info.networkinterfaces[0].ip_configurations[0].load_balancer_backend_address_pools[0] is search("{{ azure_resource_group }}-lb")
+              - nic_info.networkinterfaces[0].ip_configurations[0].load_balancer_backend_address_pools[0] is search("{{ resource_group }}-lb")
 
     - name: Test modifying VMs state (power on/off, restart, etc)
       block:
@@ -332,12 +342,13 @@
             name: virtual_machine
           vars:
             operation: 'power_off'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
 
         - name: Assert that VM was successfully powered off
           azure_rm_virtualmachine_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: vm_info
 
         - assert:
@@ -349,12 +360,13 @@
             name: virtual_machine
           vars:
             operation: 'power_on'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
 
         - name: Assert that VM was successfully powered off
           azure_rm_virtualmachine_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: vm_info
 
         - assert:
@@ -366,12 +378,13 @@
             name: virtual_machine
           vars:
             operation: 'restart'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
 
         - name: Assert that VM was successfully restarted
           azure_rm_virtualmachine_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: vm_info
 
         - assert:
@@ -383,12 +396,13 @@
             name: virtual_machine
           vars:
             operation: 'deallocate'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
 
         - name: Assert that VM was successfully deallocated
           azure_rm_virtualmachine_info:
-            resource_group: '{{ azure_resource_group }}'
+            resource_group: '{{ resource_group }}'
           register: vm_info
 
         - assert:
@@ -399,25 +413,25 @@
       block:
         - name: Get VM info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: vm_info
 
         - name: Get default nic info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: nic_info
 
         - name: Get default security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: sg_info
 
         - name: Get default public ip info
           azure_rm_publicipaddress_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: pip_info
 
@@ -434,28 +448,29 @@
             name: virtual_machine
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
             remove_on_absent: 'all_autocreated'
 
         - name: Get VM info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: vm_info
 
         - name: Get default nic info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: nic_info
 
         - name: Get default security group info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: sg_info
 
         - name: Get default public ip info
           azure_rm_publicipaddress_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: pip_info
 
         - name: Assert VM and all autocreated resources were deleted
@@ -470,7 +485,7 @@
       block:
         - name: Create network interface
           azure_rm_networkinterface:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: 'custom-nic'
             virtual_network_name: "{{ vnet.name }}"
             subnet_name: "{{ subnet.name }}"
@@ -480,6 +495,7 @@
             name: virtual_machine
           vars:
             operation: 'create'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
               name: "{{ vm_name }}"
               admin_username: 'azureuser'
@@ -495,7 +511,7 @@
 
         - name: Get resource group info
           azure_rm_resourcegroup_info:
-            name: "{{ azure_resource_group }}"
+            name: "{{ resource_group }}"
           register: rg
 
         - name: Assert that resource group was created
@@ -505,18 +521,18 @@
 
         - name: Get vm info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: vm_info
 
         - name: Get nic info
           azure_rm_networkinterface_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: nic_info
 
         - name: Get sg info
           azure_rm_securitygroup_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: sg_info
 
         - name: Assert that VM was successfully created with existing nic
@@ -532,7 +548,7 @@
       block:
         - name: Get VM info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
             name: "{{ vm_name }}"
           register: vm_info
 
@@ -546,12 +562,13 @@
             name: virtual_machine
           vars:
             operation: 'delete'
+            azure_resource_group: "{{ resource_group }}"
             azure_vm:
-              name: "{{ azure_resource_group }}-vm"
+              name: "{{ resource_group }}-vm"
 
         - name: Get VM info
           azure_rm_virtualmachine_info:
-            resource_group: "{{ azure_resource_group }}"
+            resource_group: "{{ resource_group }}"
           register: vm_info
 
         - name: Assert VM was deleted
@@ -562,7 +579,7 @@
   always:
     - name: Delete resource group
       azure_rm_resourcegroup:
-        name: "{{ azure_resource_group }}"
+        name: "{{ resource_group }}"
         state: absent
         force_delete_nonempty: yes
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Move 'azure_resource_group' out of set_facts to cover case where it is not defined in each role.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
molecule/default/tasks/*
