### PR TITLE
changing sku and how venv is created to fix issues

### DIFF
--- a/playbooks/roles/scale_virtual_machine/tasks/create.yml
+++ b/playbooks/roles/scale_virtual_machine/tasks/create.yml
@@ -32,7 +32,7 @@
     resource_group: "{{ azure_resource_group }}"
     allocation_method: static
     name: "{{ azure_load_balancer.public_ip_name }}"
-    sku: Basic
+    sku: Standard
     domain_name: "{{ azure_load_balancer.domain_name | default(omit) }}"
   register: public_ip
 
@@ -45,7 +45,7 @@
   azure.azcollection.azure_rm_loadbalancer:
     resource_group: "{{ azure_resource_group }}"
     name: "{{ azure_load_balancer.name }}"
-    sku: Basic
+    sku: Standard
     frontend_ip_configurations:
       - name: frontend
         public_ip_address: "{{ azure_load_balancer.public_ip_name }}"

--- a/playbooks/webapp.yml
+++ b/playbooks/webapp.yml
@@ -71,7 +71,17 @@
       ansible.builtin.pip:
         virtualenv: "{{ ansible_venv_path }}"
         virtualenv_python: python3
-        name: ansible==2.10.*
+        name:
+          - pip
+          - setuptools
+        state: latest
+
+    - name: Install ansible
+      ansible.builtin.pip:
+        virtualenv: "{{ ansible_venv_path }}"
+        virtualenv_python: python3
+        name: ansible
+        state: latest
 
     - name: Create application directories
       ansible.builtin.file:


### PR DESCRIPTION
These fixes are for preventing errors while running the playbook `webapp.yml`.

Both LB and Public IP were requiring to have `Standard` SKU for getting created, for the venv it was complaining that pip wasn't updated before installing any package and also it was missing setuptools.