### PR TITLE
Remove cron schedule from linters GH workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,14 +1,22 @@
 ---
 name: Linters
-'on':
+on:
   push:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+      - closed
     branches:
       - main
-  schedule:
-    - cron: '0 6 * * *'
+      - stable-*
+    tags:
+      - '*'
 
 jobs:
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,10 +8,7 @@ on:
     types:
       - opened
       - reopened
-      - labeled
-      - unlabeled
       - synchronize
-      - closed
     branches:
       - main
       - stable-*


### PR DESCRIPTION
The PR removes the "cron: '0 6 * * *'" schedule from the linters workflow.