### PR TITLE
Exclude python 3.9 for milestone in sanity test matrix

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -62,6 +62,10 @@ jobs:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.7"
             },

--- a/changelogs/fragments/20230823-update-ci-sanity-test-matrix.yaml
+++ b/changelogs/fragments/20230823-update-ci-sanity-test-matrix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add milestone/python 3.9 to the sanity test exclude matrix since 3.9 is no longer supported in milestone (https://github.com/redhat-cop/cloud.azure_ops/pull/51).


### PR DESCRIPTION
##### SUMMARY
The milestone and devel branches of ansible no longer support python 3.9. This PR adds milestone/python 3.9 to `matrix_exclude` in the sanity test Github Actions workflow.

##### ISSUE TYPE
- Bugfix Pull Request