### PR TITLE
Add arguments_specs to roles

### DIFF
--- a/changelogs/fragments/role_arg_specs.yaml
+++ b/changelogs/fragments/role_arg_specs.yaml
@@ -1,3 +1,3 @@
 ---
-trivial:
+minor_changes:
   - "Add argument_specs.yaml to validate the role variables."

--- a/changelogs/fragments/role_arg_specs.yaml
+++ b/changelogs/fragments/role_arg_specs.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Add argument_specs.yaml to validate the role variables."

--- a/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
@@ -15,7 +15,7 @@ argument_specs:
       azure_load_balancer_with_public_ip_resource_group:
         description:
           - Resource group on/from which the load balancer will reside.
-          - When `azure_load_balancer_with_public_ip_operation` is set to create, this resource group will be created if it does not exist.
+          - When O(azure_load_balancer_with_public_ip_operation) is set to create, this resource group will be created if it does not exist.
         required: true
       azure_load_balancer_with_public_ip_region:
         description:

--- a/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
@@ -1,0 +1,128 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to Create/Delete/Configure an Azure Load Balancer.
+    description:
+      - A role to Create/Delete/Configure an Azure Load Balancer.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_load_balancer_with_public_ip_operation:
+        description:
+          - Operation to perform
+        default: "create"
+        choices: ["create", "delete"]
+      azure_load_balancer_with_public_ip_resource_group:
+        description:
+          - Resource group on/from which the load balancer will reside.
+          - When `azure_load_balancer_with_public_ip_operation` is set to create, this resource group will be created if it does not exist.
+        required: true
+      azure_load_balancer_with_public_ip_region:
+        description:
+          - An Azure location for the resources.
+      azure_load_balancer_with_public_ip_tags:
+        description:
+          - metadata to the resource group.
+        type: dict
+      azure_load_balancer_with_public_ip_load_balancer:
+        description:
+          - Object used to provide details for a load balancer.
+        type: dict
+        options:
+          name:
+            description: Name of the load balancer.
+            required: true
+          public_ip_name:
+            description: Name of load balancer's public ip.
+            default: "name-ip"
+          frontend_ip_configurations:
+            description: List of dict of frontend IPs and names to be used.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Name of the frontend ip configuration.
+                default: "default"
+              public_ip_address:
+                description:
+                  - Name of existing public IP address object in the current resource group to be associated with.
+                default: <load balancers public ip>
+          backend_address_pools:
+            description: List of backend address pools where network interfaces can be attached.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Name of the backend address pool.
+                default: "default"
+          probes:
+            description: List of probe definitions used to check endpoint health.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Name of the probe.
+              port:
+                description: Probe port for communicating the probe. Possible values range from 1 to 65535, inclusive.
+              fail_count:
+                description:
+                  - The number of probes which, if there is no response, will result in stopping further traffic from being delivered to the endpoint.
+                  - This value allows endpoints to be taken out of rotation faster or slower than the typical times used in Azure.
+                default: '3'
+              interval:
+                description: Interval (in seconds) for how frequently to probe the endpoint for health status. Minimum value is '5'.
+                default: '15'
+              protocol:
+                description:
+                  - Protocol of the endpoint to be probed. If 'Tcp' is specified, a received ACK is required for the probe to be successful.
+                  - If 'Http' or 'Https' is specified, a 200 OK response from the specified URL is required for the probe to be successful.
+              request_path:
+                description:
+                  - The URI used for requesting health status from the VM.
+                  - Path is required if protocol=Http or protocol=Https. Otherwise, it is not allowed.
+          rules:
+            description: List of load balancing rules.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Name of the load balancing rule.
+              probe:
+                description: Name of the load balancer probe this rule should use.
+              backend_address_pool:
+                description: Name of backend address pool, where inbound traffic is randomly load balanced across the IPs in the pool.
+              frontend_ip_configuration:
+                description: Name of frontend ip configuration to apply rule to.
+              backend_port:
+                description:
+                  - The port used for internal connections on the endpoint.
+                  - Acceptable values are between 0 and 65535. Note that value 0 enables "Any Port".
+                enable_floating_ip:
+                  description:
+                    - Configures a virtual machine's endpoint mapping to the Frontend IP address of the Load Balancer instead of backend instance's IP.
+                frontend_port:
+                  description:
+                    - The port for the external endpoint.
+                    - Frontend port numbers must be unique across all rules within the load balancer.
+                    - Acceptable values are between 0 and 65534. Note that value 0 enables "Any Port".
+                idle_timeout:
+                  description:
+                    - The timeout for the TCP idle connection.
+                    - The value can be set between 4 and 30 minutes.
+                    - This element is only used when the protocol is set to TCP.
+                  default: '4'
+                load_distribution:
+                  description: Session persistence policy for this rule.
+                  default: 'no persistence'
+                  choices: ['SourceIP', 'SourceIPProtocol', 'no persistence']
+                protocol:
+                  description: IP protocol for the rule.
+                  choices: ['Tcp', 'Udp', 'All']
+          sku:
+            description:
+              - Load balancer SKU.
+              - Will also be applied to the public ip generated for the load balancer.
+            choices: ['Basic', 'Standard']
+          tags:
+            description: Metadata to the load balancer.
+            type: dict

--- a/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_load_balancer_with_public_ip/meta/argument_specs.yml
@@ -97,27 +97,27 @@ argument_specs:
                 description:
                   - The port used for internal connections on the endpoint.
                   - Acceptable values are between 0 and 65535. Note that value 0 enables "Any Port".
-                enable_floating_ip:
-                  description:
-                    - Configures a virtual machine's endpoint mapping to the Frontend IP address of the Load Balancer instead of backend instance's IP.
-                frontend_port:
-                  description:
-                    - The port for the external endpoint.
-                    - Frontend port numbers must be unique across all rules within the load balancer.
-                    - Acceptable values are between 0 and 65534. Note that value 0 enables "Any Port".
-                idle_timeout:
-                  description:
-                    - The timeout for the TCP idle connection.
-                    - The value can be set between 4 and 30 minutes.
-                    - This element is only used when the protocol is set to TCP.
-                  default: '4'
-                load_distribution:
-                  description: Session persistence policy for this rule.
-                  default: 'no persistence'
-                  choices: ['SourceIP', 'SourceIPProtocol', 'no persistence']
-                protocol:
-                  description: IP protocol for the rule.
-                  choices: ['Tcp', 'Udp', 'All']
+              enable_floating_ip:
+                description:
+                  - Configures a virtual machine's endpoint mapping to the Frontend IP address of the Load Balancer instead of backend instance's IP.
+              frontend_port:
+                description:
+                  - The port for the external endpoint.
+                  - Frontend port numbers must be unique across all rules within the load balancer.
+                  - Acceptable values are between 0 and 65534. Note that value 0 enables "Any Port".
+              idle_timeout:
+                description:
+                  - The timeout for the TCP idle connection.
+                  - The value can be set between 4 and 30 minutes.
+                  - This element is only used when the protocol is set to TCP.
+                default: '4'
+              load_distribution:
+                description: Session persistence policy for this rule.
+                default: 'no persistence'
+                choices: ['SourceIP', 'SourceIPProtocol', 'no persistence']
+              protocol:
+                description: IP protocol for the rule.
+                choices: ['Tcp', 'Udp', 'All']
           sku:
             description:
               - Load balancer SKU.

--- a/roles/azure_load_balancer_with_public_ip/tasks/main.yml
+++ b/roles/azure_load_balancer_with_public_ip/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- name: Check azure_load_balancer_with_public_ip_operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_load_balancer_with_public_ip_operation as 'create' or 'delete'
-  when: azure_load_balancer_with_public_ip_operation not in ['create', 'delete']
-
-- name: Ensure resource group is defined
-  ansible.builtin.fail:
-    msg: Azure resource group must be defined as azure_load_balancer_with_public_ip_resource_group
-  when: azure_load_balancer_with_public_ip_resource_group is not defined
-
-- name: Ensure load balancer name is defined
-  ansible.builtin.fail:
-    msg: Azure load balancer name must be defined as azure_load_balancer_with_public_ip_load_balancer.name
-  when: azure_load_balancer_with_public_ip_load_balancer.name is not defined
-
 - name: Get load balancer info
   azure.azcollection.azure_rm_loadbalancer_info:
     resource_group: "{{ azure_load_balancer_with_public_ip_resource_group }}"

--- a/roles/azure_manage_network_interface/meta/argument_specs.yml
+++ b/roles/azure_manage_network_interface/meta/argument_specs.yml
@@ -27,15 +27,15 @@ argument_specs:
           vnet_name:
             description:
               - Name of the existing azure virtual network where the network interface will reside.
-              - Required when `azure_manage_network_interface_operation`=create.
+              - Required when O(azure_manage_network_interface_operation=create).
           subnet_name:
             description:
               - Name of the existing azure subnet where the network interface will reside.
-              - Required when `azure_manage_network_interface_operation`=create.
+              - Required when O(azure_manage_network_interface_operation=create).
           security_group_name:
             description:
               - Name of the existing security group with which to associate the network interface.
-              - If not provided, a default security group will be created when create_with_security_group=true.
+              - If not provided, a default security group will be created when O(create_with_security_group=true).
           create_with_security_group:
             description: Whether or not a default security group should be created with the network interface.
             type: bool
@@ -43,13 +43,13 @@ argument_specs:
           os_type:
             description:
               - Determines any rules to be added to a network interface's default security group.
-              - If `os_type=Windows`, a rule allowing RDP access will be added.
-              - If `os_type=Linux`, a rule allowing SSH access will be added.
+              - If O(os_type=Windows), a rule allowing RDP access will be added.
+              - If O(os_type=Linux), a rule allowing SSH access will be added.
           enable_accelerated_networking:
-            description: Set to 'yes' to enable accelerated networking.
+            description: Set to V(yes) to enable accelerated networking.
             type: bool
           ip_forwarding:
-            description: Set to 'yes' to enable ip forwarding.
+            description: Set to V(yes) to enable ip forwarding.
             type: bool
           dns_servers:
             description: List of IP addresses representing which DNS servers the network interface should look up.
@@ -64,8 +64,8 @@ argument_specs:
                 required: true
               primary:
                 description:
-                  - Set to 'yes' to make IP configuration the primary one.
-                  - The first IP configuration is by default set to primary=yes.
+                  - Set to V(yes) to make IP configuration the primary one.
+                  - The first IP configuration is by default set to O(primary=yes).
               application_security_groups:
                 description: List of application security groups in which the IP configuration is included.
                 type: list

--- a/roles/azure_manage_network_interface/meta/argument_specs.yml
+++ b/roles/azure_manage_network_interface/meta/argument_specs.yml
@@ -1,0 +1,95 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to Create/Delete/Configure an Azure Network Interface.
+    description:
+      - A role to Create/Delete/Configure an Azure Network Interface.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_network_interface_operation:
+        description:
+          - Operation to perform
+        default: "create"
+        choices: ["create", "delete"]
+      azure_manage_network_interface_resource_group:
+        description:
+          - Resource group.
+        required: true
+      azure_manage_network_interface_interface:
+        description:
+          - Object used to provide details for a network interface.
+        type: dict
+        options:
+          name:
+            description: Name of the network interface.
+            required: true
+          vnet_name:
+            description:
+              - Name of the existing azure virtual network where the network interface will reside.
+              - Required when `azure_manage_network_interface_operation`=create.
+          subnet_name:
+            description:
+              - Name of the existing azure subnet where the network interface will reside.
+              - Required when `azure_manage_network_interface_operation`=create.
+          security_group_name:
+            description:
+              - Name of the existing security group with which to associate the network interface.
+              - If not provided, a default security group will be created when create_with_security_group=true.
+          create_with_security_group:
+            description: Whether or not a default security group should be created with the network interface.
+            type: bool
+            default: true
+          os_type:
+            description:
+              - Determines any rules to be added to a network interface's default security group.
+              - If `os_type=Windows`, a rule allowing RDP access will be added.
+              - If `os_type=Linux`, a rule allowing SSH access will be added.
+          enable_accelerated_networking:
+            description: Set to 'yes' to enable accelerated networking.
+            type: bool
+          ip_forwarding:
+            description: Set to 'yes' to enable ip forwarding.
+            type: bool
+          dns_servers:
+            description: List of IP addresses representing which DNS servers the network interface should look up.
+            type: list
+          ip_configurations:
+            description: List of IP configurations.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Name of the IP configuration.
+                required: true
+              primary:
+                description:
+                  - Set to 'yes' to make IP configuration the primary one.
+                  - The first IP configuration is by default set to primary=yes.
+              application_security_groups:
+                description: List of application security groups in which the IP configuration is included.
+                type: list
+                elements: str
+              load_balancer_backend_address_pools:
+                description: List of existing load balancer backend address pools in which the network interface will be load balanced.
+                type: list
+                elements: str
+              private_ip_address:
+                description: Private IP address for the IP configuration.
+              private_ip_address_version:
+                description: Ip version.
+                default: 'IPv4'
+                choices: ['IPv4', 'IPv6']
+              private_ip_allocation_method:
+                description: Ip allocation method.
+                default: 'Dynamic'
+                choices: ['Dynamic', 'Static']
+              public_ip_address_name:
+                description: Name of the existing public IP address to be assigned to the network interface.
+              public_ip_allocation_method:
+                description: Ip allocation method.
+                default: 'Dynamic'
+                choices: ['Dynamic', 'Static']
+          tags:
+            description: Metadata for the network interface.
+            type: dict

--- a/roles/azure_manage_network_interface/tasks/main.yml
+++ b/roles/azure_manage_network_interface/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- name: Check operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_manage_network_interface_operation as 'create' or 'delete'
-  when: azure_manage_network_interface_operation not in ['create', 'delete']
-
-- name: Ensure resource group is defined
-  ansible.builtin.fail:
-    msg: Azure resource group name must be defined as azure_manage_network_interface_resource_group
-  when: azure_manage_network_interface_resource_group is not defined
-
-- name: Ensure network interface name is defined
-  ansible.builtin.fail:
-    msg: "Missing parameter: key 'name' not found in azure_manage_network_interface_interface"
-  when: azure_manage_network_interface_interface.name is not defined
-
 - name: Get resource group info
   azure.azcollection.azure_rm_resourcegroup_info:
     name: "{{ azure_manage_network_interface_resource_group }}"

--- a/roles/azure_manage_networking_stack/meta/argument_specs.yml
+++ b/roles/azure_manage_networking_stack/meta/argument_specs.yml
@@ -1,0 +1,48 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to Create/Delete/Configure an Azure Network Interface.
+    description:
+      - This role create/delete azure networking stack which include virtual network and add/delete a subnet.
+      - It will also create the resource group on which the networking stack should be attached, if not existing.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_networking_stack_operation:
+        description:
+          - Operation to perform
+        choices: ["create", "delete"]
+        required: true
+      azure_manage_networking_stack_delete_option:
+        description:
+          - When deleting created resources, this is used to specified wether to remove only the subnet, the virtual network or all (including resource group).
+        default: 'all'
+        choices: ['subnet', 'virtual_network', 'all']
+      azure_manage_networking_stack_resource_group:
+        description:
+          - Resource group on which the networking stack should be attached.
+        required: true
+      azure_manage_networking_stack_virtual_network:
+        description:
+          - Name of the virtual network to create/delete.
+      azure_manage_networking_stack_subnet:
+        description:
+          - Name of the subnet to create/delete.
+      azure_manage_networking_stack_security_group:
+        description:
+          - Existing security group with which to associate the subnet.
+      azure_manage_networking_stack_region:
+        description: An Azure location for the virtual network to create.
+      azure_manage_networking_stack_vnet_address_prefixes_cidr:
+        description:
+          - List of IPv4 address ranges for virtual network where each is formatted using CIDR notation.
+          - Required when creating a new virtual network.
+        type: list
+        elements: str
+      azure_manage_networking_stack_subnet_address_prefixes_cidr:
+        description:
+          - CIDR defining the IPv4 and IPv6 address space of the subnet.
+          - Must be valid within the context of the virtual network.
+      azure_manage_networking_stack_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict

--- a/roles/azure_manage_postgresql/meta/argument_specs.yml
+++ b/roles/azure_manage_postgresql/meta/argument_specs.yml
@@ -1,0 +1,135 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to Create/Delete/Configure an Azure Database for PostgreSQL server.
+    description:
+      - A role to Create/Delete/Configure an Azure Database for PostgreSQL server.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_postgresql_operation:
+        description: Operation to perform.
+        default: "create"
+        choices: ["create", "delete"]
+      azure_manage_postgresql_delete_option:
+        description:
+          - used with `azure_manage_postgresql_operation` set to delete.
+          - This option specifies wether to delete all resources including resource group and PostgreSQL server, or only the postgresql server.
+          - If not specified only the firewall rules and/or the configuration settings and/or the database instances defined using dedicated variables will be removed from the PostgreSQL Server.
+        choices: ['all', 'server']
+      azure_manage_postgresql_resource_group:
+        description:
+          - Resource group on/from which the Database server will be created/deleted.
+        required: true
+      azure_manage_postgresql_region:
+        description: An Azure location for the resources.
+      azure_manage_postgresql_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict
+        elements: str
+      azure_manage_postgresql_postgresql_name:
+        description: The name of the Server.
+      azure_manage_postgresql_postgresql_sku:
+        description: The SKU (pricing tier) of the server.
+        required: true
+        type: dict
+        options:
+          name:
+            description:
+              - The name of the SKU, typically, tier + family + cores, for example B_Gen4_1, GP_Gen5_8.
+          tier:
+            description: The tier of the particular SKU. Valid values are Basic, Standard.
+          capacity:
+            description: The scale up/out capacity, representing the server's compute units.
+          size:
+            description: The size code, to be interpreted by resource as appropriate.
+      azure_manage_postgresql_postgresql_storage_mb:
+        description: The maximum storage allowed for a server.
+      azure_manage_postgresql_postgresql_geo_redundant_backup:
+        description:
+          - Choose between locally redundant(default) or geo-redundant backup.
+          - This cannot be updated after first deployment.
+        default: false
+        type: bool
+      azure_manage_postgresql_postgresql_backup_retention_days:
+        description: Backup retention period between 7 and 35 days.
+        default: '7'
+      azure_manage_postgresql_postgresql_version:
+        description: Server version.
+        choices: ['9.5', '9.6', '10', '11']
+        default: '9.5'
+      azure_manage_postgresql_postgresql_enforce_ssl:
+        description: Enable SSL enforcement.
+        default: False
+        type: bool
+      azure_manage_postgresql_postgresql_storage_autogrow:
+        description: Enable storage autogrow.
+        default: False
+        type: bool
+      azure_manage_postgresql_postgresql_admin_username:
+        description:
+          - The administrator's login name of a server.
+          - Can only be specified when the server is being created (and is required for creation).
+      azure_manage_postgresql_postgresql_admin_password:
+        description:
+          - The password of the administrator login.
+          - When this is not defined, the role will generated a password that can be read later in the variable name.
+      azure_manage_postgresql_postgresql_create_mode:
+        description:
+          - Create mode of SQL Server.
+          - restore from geo redundant (geo_restore), or restore from point in time (point_in_time_restore).
+        choices: ['default, geo_restore', 'point_in_time_restore']
+        default: 'default'
+      azure_manage_postgresql_postgresql_source_server_id:
+        description:
+          - Id of the source server if azure_manage_postgresql_postgresql_create_mode is set to default.
+      azure_manage_postgresql_postgresql_restore_point_in_time:
+        description:
+          - Restore point creation time (ISO8601 format), specifying the time to restore from.
+          - Required if azure_manage_postgresql_postgresql_create_mode is set to point_in_time_restore.
+      azure_manage_postgresql_postgresql_settings:
+        description:
+          - list of configuration settings for PostgreSQL Server.
+        type: list
+        elements: dict
+        options:
+          name:
+            description: setting name.
+          value:
+            description: value of the setting.
+      azure_manage_postgresql_postgresql_firewall_rules:
+        description: list of firewall rule to add/remove to the PostgreSQL Server.
+        type: list
+        elements: dict
+        options:
+          name:
+            description: The name of the PostgreSQL firewall rule.
+          start_ip_address:
+            description:
+              - The start IP address of the PostgreSQL firewall rule.
+              - Must be IPv4 format.
+          end_ip_address:
+            description:
+              - The end IP address of the PostgreSQL firewall rule.
+              - Must be IPv4 format.
+      azure_manage_postgresql_postgresql_database_instances:
+        description:
+          - list of database instances to create/delete on/from the PostgreSQL Server.
+        type: list
+        elements: dict
+        options:
+          name:
+            description: The name of the PostgreSQL database instance.
+          charset:
+            description:
+              - The charset of the database. Check PostgreSQL documentation for possible values.
+              - This is only set on creation, use force to recreate a database if the values don't match.
+          collation:
+            description:
+              -The collation of the database.
+              - Check PostgreSQL documentation. This is only set on creation, use force to recreate a database if the values don't match.
+          force:
+            description:
+              - When set to `True`, will delete and recreate the existing PostgreSQL database if any of the properties don't match what is set.
+              - Ignore when operation is set to `delete`.
+            type: bool

--- a/roles/azure_manage_postgresql/meta/argument_specs.yml
+++ b/roles/azure_manage_postgresql/meta/argument_specs.yml
@@ -13,7 +13,7 @@ argument_specs:
         choices: ["create", "delete"]
       azure_manage_postgresql_delete_option:
         description:
-          - used with `azure_manage_postgresql_operation` set to delete.
+          - used with O(azure_manage_postgresql_operation=delete).
           - This option specifies wether to delete all resources including resource group and PostgreSQL server, or only the postgresql server.
           - If not specified only the firewall rules and/or the configuration settings and/or the database instances defined using dedicated variables will be removed from the PostgreSQL Server.
         choices: ['all', 'server']
@@ -77,7 +77,7 @@ argument_specs:
       azure_manage_postgresql_postgresql_create_mode:
         description:
           - Create mode of SQL Server.
-          - restore from geo redundant (geo_restore), or restore from point in time (point_in_time_restore).
+          - restore from geo redundant V(geo_restore), or restore from point in time V(point_in_time_restore).
         choices: ['default, geo_restore', 'point_in_time_restore']
         default: 'default'
       azure_manage_postgresql_postgresql_source_server_id:
@@ -130,6 +130,6 @@ argument_specs:
               - Check PostgreSQL documentation. This is only set on creation, use force to recreate a database if the values don't match.
           force:
             description:
-              - When set to `True`, will delete and recreate the existing PostgreSQL database if any of the properties don't match what is set.
-              - Ignore when operation is set to `delete`.
+              - When set to V(True), will delete and recreate the existing PostgreSQL database if any of the properties don't match what is set.
+              - Ignore when operation is set to V(delete).
             type: bool

--- a/roles/azure_manage_postgresql/tasks/main.yml
+++ b/roles/azure_manage_postgresql/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- name: Check operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_manage_postgresql_operation as 'create' or 'delete'
-  when: azure_manage_postgresql_operation not in ['create', 'delete']
-
-- name: Check Azure resource group
-  ansible.builtin.fail:
-    msg: Azure resource group must be defined as azure_manage_postgresql_resource_group
-  when: azure_manage_postgresql_resource_group is not defined
-
-- name: Check Azure PostgreSQL server name
-  ansible.builtin.fail:
-    msg: Azure Postgresql server name must be defined as azure_manage_postgresql_postgresql_name
-  when: azure_manage_postgresql_postgresql_name is not defined
-
 - name: Get server info
   azure.azcollection.azure_rm_postgresqlserver_info:
     resource_group: "{{ azure_manage_postgresql_resource_group }}"

--- a/roles/azure_manage_resource_group/meta/argument_specs.yml
+++ b/roles/azure_manage_resource_group/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to manage Azure Resource Group. User can create or delete resource group.
+    description:
+      - A role to manage Azure Resource Group. User can create or delete resource group.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_resource_group_operation:
+        description: Operation to perform.
+        choices: ["create", "delete"]
+        required: true
+      azure_manage_resource_group_name:
+        description: Resource group to create or delete.
+        required: true
+      azure_manage_resource_group_region:
+        description: An Azure location for the resource group to create.
+      azure_manage_resource_group_lock_resource_group:
+        description: If set to 'true', will lock the resource group created.
+        type: bool
+      azure_manage_resource_group_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict
+      azure_manage_resource_group_force_delete_nonempty:
+        description: Remove a resource group and all associated resources.
+      azure_manage_resource_group_force_delete_locked:
+        description: Remove a resource group even if it is locked.

--- a/roles/azure_manage_resource_group/meta/argument_specs.yml
+++ b/roles/azure_manage_resource_group/meta/argument_specs.yml
@@ -17,7 +17,7 @@ argument_specs:
       azure_manage_resource_group_region:
         description: An Azure location for the resource group to create.
       azure_manage_resource_group_lock_resource_group:
-        description: If set to 'true', will lock the resource group created.
+        description: If set to V(true), will lock the resource group created.
         type: bool
       azure_manage_resource_group_tags:
         description: Dictionary of string:string pairs to assign as metadata to the object.

--- a/roles/azure_manage_resource_group/tasks/main.yml
+++ b/roles/azure_manage_resource_group/tasks/main.yml
@@ -1,13 +1,3 @@
 ---
-- name: Check azure_manage_resource_group_operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_manage_resource_group_operation as 'create' or 'delete'
-  when: azure_manage_resource_group_operation not in ['create', 'delete']
-
-- name: Check Resource group name
-  ansible.builtin.fail:
-    msg: Azure Resource group name must be defined as azure_manage_resource_group_name
-  when: azure_manage_resource_group_name is not defined
-
 - name: Create or delete resource group
   ansible.builtin.include_tasks: "{{ azure_manage_resource_group_operation }}.yml"

--- a/roles/azure_manage_security_group/meta/argument_specs.yml
+++ b/roles/azure_manage_security_group/meta/argument_specs.yml
@@ -46,10 +46,10 @@ argument_specs:
               destination_address_prefix:
                 description:
                   - The destination address prefix. CIDR or destination IP range.
-                  - Asterisk '*' can be used to match all source IPs.
-                  - Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                  - Asterisk V(*) can be used to match all source IPs.
+                  - Default tags such as V(VirtualNetwork), V(AzureLoadBalancer) and V(Internet) can also be used.
                   - Accepts string or a list of strings.
-                  - Asterisk '*' and default tags can only be specified as single string, not as a list of strings.
+                  - Asterisk V(*) and default tags can only be specified as single string, not as a list of strings.
                 type: raw
               destination_application_security_groups:
                 description:
@@ -60,7 +60,7 @@ argument_specs:
               destination_port_range:
                 description:
                   - Port or range of ports to which traffic is headed.
-                  - Can be a string or list of strings. Default is '*'.
+                  - Can be a string or list of strings. Default is V(*).
                 type: raw
               direction:
                 description: Indicates direction of traffic flow.
@@ -72,18 +72,18 @@ argument_specs:
                 default: '*'
               source_address_prefix:
                 description:
-                  - The CIDR or source IP range. Asterisk '*' can be used to match all source IPs.
-                  - Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                  - The CIDR or source IP range. Asterisk V(*) can be used to match all source IPs.
+                  - Default tags such as V(VirtualNetwork), V(AzureLoadBalancer) and V(Internet) can also be used.
                   - If this is an ingress rule, specifies where network traffic originates from.
                   - Accepts string or a list of strings.
-                  - Asterisk '*' and default tags can only be specified as a single string, not as a list of strings.
+                  - Asterisk V(*) and default tags can only be specified as a single string, not as a list of strings.
                 type: raw
               source_port_range:
                 description: Port or range of ports from which traffic originates. Can be a string or list of strings.
                 default: '*'
                 type: raw
               purge_rules:
-                description: If set to 'yes', removes any existing, non-default, rules that are not specified in rules above.
+                description: If set to V(yes), removes any existing, non-default, rules that are not specified in rules above.
                 type: bool
               rules_to_remove:
                 description: List of strings representing the names of security group rules to be removed from the security group.

--- a/roles/azure_manage_security_group/meta/argument_specs.yml
+++ b/roles/azure_manage_security_group/meta/argument_specs.yml
@@ -1,0 +1,93 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to manage an Azure Security Group. User can create or delete a security group, as well as add/remove rules from a security group.
+    description:
+      - A role to Create/Delete/Configure an Azure Security Group.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_security_group_operation:
+        description: Operation to perform.
+        default: 'create'
+        choices: ['create', 'delete']
+      azure_manage_security_group_resource_group:
+        description: Resource group on/from which the security group will reside.
+        required: true
+      azure_manage_security_group_region:
+        description: Azure region.
+        required: true
+      azure_manage_security_group_security_group:
+        description: Object used to provide details for a security group.
+        type: dict
+        options:
+          name:
+            description: Name of the security group.
+            required: true
+          rules:
+            description: List of security rules to apply to a subnet or NIC.
+            type: list
+            elements: dict
+            options:
+              name:
+                description: Unique name of rule.
+                required: true
+              priority:
+                description: Order in which to apply the rule. Must be a unique integer between 100 and 4096 inclusive.
+                required: true
+              access:
+                description:
+                  - Allow to allow traffic flow.
+                  - Deny to deny traffic flow.
+                default: 'Allow'
+                choices: ['Allow', 'Deny']
+              description:
+                description: description of the rule
+              destination_address_prefix:
+                description:
+                  - The destination address prefix. CIDR or destination IP range.
+                  - Asterisk '*' can be used to match all source IPs.
+                  - Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                  - Accepts string or a list of strings.
+                  - Asterisk '*' and default tags can only be specified as single string, not as a list of strings.
+                type: raw
+              destination_application_security_groups:
+                description:
+                  - List of the destination application security groups.
+                  - It could be a list of resource ids, names in same resource group, or dicts containing resource_group and name.
+                  - It is mutually exclusive with destination_address_prefix and destination_address_prefixes.
+                type: list
+              destination_port_range:
+                description:
+                  - Port or range of ports to which traffic is headed.
+                  - Can be a string or list of strings. Default is '*'.
+                type: raw
+              direction:
+                description: Indicates direction of traffic flow.
+                choices: ['Inbound', 'Outbound']
+                default: 'Inbound'
+              protocol:
+                description: Accepted traffic protocol.
+                choices: ['*', 'Udp', 'Tcp', 'Icmp']
+                default: '*'
+              source_address_prefix:
+                description:
+                  - The CIDR or source IP range. Asterisk '*' can be used to match all source IPs.
+                  - Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                  - If this is an ingress rule, specifies where network traffic originates from.
+                  - Accepts string or a list of strings.
+                  - Asterisk '*' and default tags can only be specified as a single string, not as a list of strings.
+                type: raw
+              source_port_range:
+                description: Port or range of ports from which traffic originates. Can be a string or list of strings.
+                default: '*'
+                type: raw
+              purge_rules:
+                description: If set to 'yes', removes any existing, non-default, rules that are not specified in rules above.
+                type: bool
+              rules_to_remove:
+                description: List of strings representing the names of security group rules to be removed from the security group.
+                type: list
+          tags:
+            description: Dictionary of string:string pairs to assign as metadata to the security group.
+            type: dict

--- a/roles/azure_manage_security_group/tasks/main.yml
+++ b/roles/azure_manage_security_group/tasks/main.yml
@@ -1,24 +1,4 @@
 ---
-- name: Check operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_manage_security_group_operation as 'create' or 'delete'
-  when: azure_manage_security_group_operation not in ['create', 'delete']
-
-- name: Check resource group name
-  ansible.builtin.fail:
-    msg: Azure resource group name must be defined as azure_manage_security_group_resource_group
-  when: azure_manage_security_group_resource_group is not defined
-
-- name: Check azure region
-  ansible.builtin.fail:
-    msg: Azure region must be defined as azure_manage_security_group_region
-  when: azure_manage_security_group_region is not defined
-
-- name: Check security group name
-  ansible.builtin.fail:
-    msg: "Missing parameter: key 'name' not found in azure_manage_security_group_security_group"
-  when: azure_manage_security_group_security_group.name is not defined
-
 - name: Get resource group info
   azure.azcollection.azure_rm_resourcegroup_info:
     name: "{{ azure_manage_security_group_resource_group }}"

--- a/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
@@ -1,0 +1,105 @@
+---
+argument_specs:
+  main:
+    version_added: 2.0.0
+    short_description: A role to Create/Delete/Configure an Azure Virtual Machine.
+    description:
+      - A role to Create/Delete/Configure an Azure Virtual Machine.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_virtual_machine_with_public_ip_operation:
+        description:
+          - Operation to perform
+        default: "create"
+        choices: ['create', 'delete', 'power_on', 'power_off', 'deallocate', 'restart']
+      azure_virtual_machine_with_public_ip_remove_on_absent:
+        description:
+          - Specify which resources to remove when `azure_virtual_machine_with_public_ip_operation='delete'`.
+          - 'all' removes all resources attached to the VM being removed.
+          - 'all_autocreated' removes the resources that were automatically created while provisioning the VM (public ip, network interface, security group).
+          - To remove only specific resources, use the values 'network_interfaces', 'virtual_storage', or 'public_ips'.
+        default: 'all'
+      azure_virtual_machine_with_public_ip_resource_group:
+        description:
+          - Resource group on/from which the virtual machine will reside.
+          - When `azure_virtual_machine_with_public_ip_operation='create'`, this resource group will be created if it does not exist.
+        required: true
+      azure_virtual_machine_with_public_ip_region:
+        description: An Azure location for the resources.
+      azure_virtual_machine_with_public_ip_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the resource group.
+        type: dict
+      azure_virtual_machine_with_public_ip_vm:
+        description: Object used to provide details for a virtual machine.
+        type: dict
+        options:
+          name:
+            description: Name of the virtual machine.
+            required: true
+          admin_username:
+            description: Administrator's login name of a server. Required for creation.
+          admin_password:
+            description: Password of the administrator login. Not required when `os='Linux'` and `ssh_pw_enabled='false'`.
+          size:
+            description: Valid Azure VM size. Choices vary depending on the subscription and location.
+          network_interfaces:
+            description:
+              - List of network interfaces to add to the VM.
+              - Can be a string of name or resource ID of the network interface, can also be a dict containing 'resource_group' and 'name' of the network interface.
+              - A default network interface will be created if not provided.
+            type: raw
+          os:
+            description: Type of Operating System.
+            default: 'Linux'
+          availability_set:
+            description: Name or ID of existing availability set to add the VM to.
+          image:
+            description:
+              - The image used to build the VM. For custom images, the name of the image. To narrow the search to a specific resource group, a dict with the keys name and resource_group.
+              - For Marketplace images, a dict with the keys publisher, offer, sku, and version.
+              - Set `version=latest` to get the most recent version of a given image.
+          ssh_pw_enabled:
+            description: Enable/disable SSH passwords.
+            choices: ['yes', 'no']
+            default: 'yes'
+          ssh_public_keys:
+            description:
+              - List of SSH keys when `os='Linux'`.
+              - Accepts a list of dicts where each dictionary contains two keys, 'path' and 'key_data'.
+              - Set path to the default location of the authorized_keys files. For example, path=/home//.ssh/authorized_keys. Set key_data to the actual value of the public key.
+            type: raw
+          data_disks:
+            description: List of data disks.
+            type: list
+          lun:
+            description: Logical unit number for data disk. Must be unique for each data disk attached to a VM.
+          caching:
+            description: Type of data disk caching.
+            choices: ['ReadOnly', 'ReadWrite']
+            default: 'ReadOnly'
+          disk_size_gb:
+            description:
+              - Initial disk size in GB for blank data disks. Cannot be larger than 1023 GB.
+              - Can only be modified when VM is deallocated.
+          managed_disk_type:
+            description: Managed data disk type.
+          storage_account_name:
+            description: Name of an existing storage account that supports creation of VHD blobs.
+          storage_blob_name:
+            description: Name of storage blob used to hold the OS disk image of the VM.
+          storage_container_name:
+            description: Name of the container to use within the storage account to store VHD blobs.
+            default: 'vhds'
+      azure_virtual_machine_with_public_ip_availability_set:
+        description: Object used to provide details for an availability set to be used by a VM.
+        type: dict
+        options:
+          name:
+            description: Name of the availability set.
+            required: true
+          platform_fault_domain_count:
+            description:
+              - Fault domains define the group of virtual machines that share a common power source and network switch.
+              - Should be between 1 and 3.
+          platform_update_domain_count:
+            description: Update domains indicate groups of virtual machines and underlying physical hardware that can be rebooted at the same time.

--- a/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
@@ -15,8 +15,8 @@ argument_specs:
       azure_virtual_machine_with_public_ip_remove_on_absent:
         description:
           - Specify which resources to remove when `azure_virtual_machine_with_public_ip_operation='delete'`.
-          - 'all' removes all resources attached to the VM being removed.
-          - 'all_autocreated' removes the resources that were automatically created while provisioning the VM (public ip, network interface, security group).
+          - Value 'all' removes all resources attached to the VM being removed.
+          - Value 'all_autocreated' removes the resources that were automatically created while provisioning the VM.
           - To remove only specific resources, use the values 'network_interfaces', 'virtual_storage', or 'public_ips'.
         default: 'all'
       azure_virtual_machine_with_public_ip_resource_group:

--- a/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
+++ b/roles/azure_virtual_machine_with_public_ip/meta/argument_specs.yml
@@ -14,15 +14,15 @@ argument_specs:
         choices: ['create', 'delete', 'power_on', 'power_off', 'deallocate', 'restart']
       azure_virtual_machine_with_public_ip_remove_on_absent:
         description:
-          - Specify which resources to remove when `azure_virtual_machine_with_public_ip_operation='delete'`.
-          - Value 'all' removes all resources attached to the VM being removed.
-          - Value 'all_autocreated' removes the resources that were automatically created while provisioning the VM.
-          - To remove only specific resources, use the values 'network_interfaces', 'virtual_storage', or 'public_ips'.
+          - Specify which resources to remove when O(azure_virtual_machine_with_public_ip_operation=delete).
+          - V(all) removes all resources attached to the VM being removed.
+          - V(all_autocreated) removes the resources that were automatically created while provisioning the VM.
+          - To remove only specific resources, use the values V(network_interfaces), V(virtual_storage), or V(public_ips).
         default: 'all'
       azure_virtual_machine_with_public_ip_resource_group:
         description:
           - Resource group on/from which the virtual machine will reside.
-          - When `azure_virtual_machine_with_public_ip_operation='create'`, this resource group will be created if it does not exist.
+          - When O(azure_virtual_machine_with_public_ip_operation=create), this resource group will be created if it does not exist.
         required: true
       azure_virtual_machine_with_public_ip_region:
         description: An Azure location for the resources.
@@ -39,7 +39,7 @@ argument_specs:
           admin_username:
             description: Administrator's login name of a server. Required for creation.
           admin_password:
-            description: Password of the administrator login. Not required when `os='Linux'` and `ssh_pw_enabled='false'`.
+            description: Password of the administrator login. Not required when O(os=Linux) and O(ssh_pw_enabled=false).
           size:
             description: Valid Azure VM size. Choices vary depending on the subscription and location.
           network_interfaces:
@@ -57,14 +57,14 @@ argument_specs:
             description:
               - The image used to build the VM. For custom images, the name of the image. To narrow the search to a specific resource group, a dict with the keys name and resource_group.
               - For Marketplace images, a dict with the keys publisher, offer, sku, and version.
-              - Set `version=latest` to get the most recent version of a given image.
+              - Set O(version=latest) to get the most recent version of a given image.
           ssh_pw_enabled:
             description: Enable/disable SSH passwords.
             choices: ['yes', 'no']
             default: 'yes'
           ssh_public_keys:
             description:
-              - List of SSH keys when `os='Linux'`.
+              - List of SSH keys when O(os=Linux).
               - Accepts a list of dicts where each dictionary contains two keys, 'path' and 'key_data'.
               - Set path to the default location of the authorized_keys files. For example, path=/home//.ssh/authorized_keys. Set key_data to the actual value of the public key.
             type: raw

--- a/roles/azure_virtual_machine_with_public_ip/tasks/main.yml
+++ b/roles/azure_virtual_machine_with_public_ip/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- name: Check operation validation
-  ansible.builtin.fail:
-    msg: Please provide azure_virtual_machine_with_public_ip_operation as 'create', 'delete', 'power_on', 'power_off', 'deallocate', or 'restart'
-  when: azure_virtual_machine_with_public_ip_operation not in ['create', 'delete', 'power_on', 'power_off', 'deallocate', 'restart']
-
-- name: Ensure resource group is defined
-  ansible.builtin.fail:
-    msg: Azure resource group name must be defined as azure_virtual_machine_with_public_ip_resource_group
-  when: azure_virtual_machine_with_public_ip_resource_group is not defined
-
-- name: Ensure vm name is defined
-  ansible.builtin.fail:
-    msg: "Missing parameter: key 'name' not found in azure_virtual_machine_with_public_ip_vm"
-  when: azure_virtual_machine_with_public_ip_vm.name is not defined
-
 - name: Replace invalid chars in name
   ansible.builtin.set_fact:
     vm_name: "{{ azure_virtual_machine_with_public_ip_vm.name | regex_replace('[^a-zA-Z0-9]', '-') }}"


### PR DESCRIPTION
This PR adds argument_specs.yml to the roles to enable validation of arguments.
This aligns with https://github.com/ansible-collections/cloud-content-handbook/blob/main/Roles-arguments_validation.md and https://github.com/redhat-cop/automation-good-practices/tree/main/roles#argument-validation