### PR TITLE
Added integration for test_azure_manage_resource_group role

### DIFF
--- a/roles/azure_manage_resource_group/tasks/delete.yml
+++ b/roles/azure_manage_resource_group/tasks/delete.yml
@@ -16,6 +16,11 @@
         resource_group: "{{ azure_manage_resource_group_name }}"
       with_items: "{{ result.locks }}"
 
+- name: Sleep for 10 seconds and continue with play
+  ansible.builtin.wait_for:
+    timeout: 10
+  delegate_to: localhost
+
 - name: Delete resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ azure_manage_resource_group_name }}"

--- a/roles/azure_manage_resource_group/tasks/delete.yml
+++ b/roles/azure_manage_resource_group/tasks/delete.yml
@@ -16,11 +16,6 @@
         resource_group: "{{ azure_manage_resource_group_name }}"
       with_items: "{{ result.locks }}"
 
-- name: Sleep for 10 seconds and continue with play
-  ansible.builtin.wait_for:
-    timeout: 10
-  delegate_to: localhost
-
 - name: Delete resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ azure_manage_resource_group_name }}"

--- a/tests/integration/targets/test_azure_manage_resource_group/aliases
+++ b/tests/integration/targets/test_azure_manage_resource_group/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+role/azure_manage_resource_group
+time=2m

--- a/tests/integration/targets/test_azure_manage_resource_group/defaults/main.yml
+++ b/tests/integration/targets/test_azure_manage_resource_group/defaults/main.yml
@@ -2,6 +2,6 @@
 # defaults file for azure_manage_resource_group
 
 # Default values for role variables
-azure_manage_resource_group_name_test: "{{ resource_prefix }}-test-resource-group"
-azure_manage_resource_group_tags_test: 
+azure_manage_resource_group_name: "{{ resource_prefix }}-test-resource-group"
+azure_manage_resource_group_tags: 
   resource_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/test_azure_manage_resource_group/defaults/main.yml
+++ b/tests/integration/targets/test_azure_manage_resource_group/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for azure_manage_resource_group
+
+# Default values for role variables
+azure_manage_resource_group_name_test: "{{ resource_prefix }}-test-resource-group"
+azure_manage_resource_group_tags_test: 
+  resource_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/test_azure_manage_resource_group/tasks/main.yml
+++ b/tests/integration/targets/test_azure_manage_resource_group/tasks/main.yml
@@ -17,21 +17,19 @@
         name: cloud.azure_ops.azure_manage_resource_group
       vars:
         azure_manage_resource_group_operation: create
-        azure_manage_resource_group_name: "{{ azure_manage_resource_group_name_test }}"
-        azure_manage_resource_group_tags: "{{ azure_manage_resource_group_tags_test }}"
 
     - name: Get Resource Group info
       azure.azcollection.azure_rm_resourcegroup_info:
-        name: "{{ azure_manage_resource_group_name_test }}"
+        name: "{{ azure_manage_resource_group_name }}"
       register: rg_info
 
     - name: Assert that Resource Group was created without locking
       ansible.builtin.assert:
         that:
           - rg_info.resourcegroups | length == 1
-          - rg_info.resourcegroups[0].name == azure_manage_resource_group_name_test
+          - rg_info.resourcegroups[0].name == azure_manage_resource_group_name
           - rg_info.resourcegroups[0].location == azure_manage_resource_group_region
-          - rg_info.resourcegroups[0].tags == azure_manage_resource_group_tags_test
+          - rg_info.resourcegroups[0].tags == azure_manage_resource_group_tags
 
     # Test: Delete Resource Group without locking
     - name: Delete Resource Group without locking
@@ -39,11 +37,10 @@
         name: cloud.azure_ops.azure_manage_resource_group
       vars:
         azure_manage_resource_group_operation: delete
-        azure_manage_resource_group_name: "{{ azure_manage_resource_group_name_test }}"
 
     - name: Get Resource Group
       azure.azcollection.azure_rm_resourcegroup_info:
-        name: "{{ azure_manage_resource_group_name_test }}"
+        name: "{{ azure_manage_resource_group_name }}"
       register: rg_info
 
     - name: Assert that Resource Group was deleted without locking
@@ -54,13 +51,13 @@
   always:
     - name: Get Resource Group info
       azure.azcollection.azure_rm_resourcegroup_info:
-        name: "{{ azure_manage_resource_group_name_test }}"
+        name: "{{ azure_manage_resource_group_name }}"
       register: rg_info
     
     # Only delete if resource group exists
     - name: Delete Resource Group 
       azure.azcollection.azure_rm_resourcegroup:
-        name: "{{ azure_manage_resource_group_name_test }}"
+        name: "{{ azure_manage_resource_group_name }}"
         force_delete_nonempty: true
         state: absent
       when: rg_info.resourcegroups | length > 0  

--- a/tests/integration/targets/test_azure_manage_resource_group/tasks/main.yml
+++ b/tests/integration/targets/test_azure_manage_resource_group/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+# Determine Azure Region
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Set Azure Region for azure_manage_resource_group Role
+  ansible.builtin.set_fact:
+    azure_manage_resource_group_region: "{{ __rg_info.resourcegroups.0.location }}"
+
+- name: Test role cloud.azure_ops.azure_manage_resource_group without locking var
+  block:
+    # Test: Create Resource Group without locking
+    - name: Create Resource Group without locking
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_resource_group
+      vars:
+        azure_manage_resource_group_operation: create
+        azure_manage_resource_group_name: "{{ azure_manage_resource_group_name_test }}"
+        azure_manage_resource_group_tags: "{{ azure_manage_resource_group_tags_test }}"
+
+    - name: Get Resource Group info
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ azure_manage_resource_group_name_test }}"
+      register: rg_info
+
+    - name: Assert that Resource Group was created without locking
+      ansible.builtin.assert:
+        that:
+          - rg_info.resourcegroups | length == 1
+          - rg_info.resourcegroups[0].name == azure_manage_resource_group_name_test
+          - rg_info.resourcegroups[0].location == azure_manage_resource_group_region
+          - rg_info.resourcegroups[0].tags == azure_manage_resource_group_tags_test
+
+    # Test: Delete Resource Group without locking
+    - name: Delete Resource Group without locking
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_resource_group
+      vars:
+        azure_manage_resource_group_operation: delete
+        azure_manage_resource_group_name: "{{ azure_manage_resource_group_name_test }}"
+
+    - name: Get Resource Group
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ azure_manage_resource_group_name_test }}"
+      register: rg_info
+
+    - name: Assert that Resource Group was deleted without locking
+      ansible.builtin.assert:
+        that:
+          - rg_info.resourcegroups | length == 0
+
+  always:
+    - name: Get Resource Group info
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ azure_manage_resource_group_name_test }}"
+      register: rg_info
+    
+    # Only delete if resource group exists
+    - name: Delete Resource Group 
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ azure_manage_resource_group_name_test }}"
+        force_delete_nonempty: true
+        state: absent
+      when: rg_info.resourcegroups | length > 0  


### PR DESCRIPTION
Added integration test for test_azure_manage_resource_group role.
This is the first PR for the positive scenario without using "locking":

- creation and deletion of resource group

<img width="1262" alt="Screenshot 2024-05-16 at 14 41 58" src="https://github.com/redhat-cop/cloud.azure_ops/assets/58551443/eee112c9-b919-40c8-8075-9f04f87eb5a9">
