### PR TITLE
Add a timeout in the delete task in azure_manage_resource_group role

### DIFF
--- a/changelogs/fragments/20240508-azure_manage_resource_group.yml
+++ b/changelogs/fragments/20240508-azure_manage_resource_group.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Added a timeout (as a temporary solution) in the delete task of the azure_manage_resource_group role
+  

--- a/roles/azure_manage_resource_group/tasks/delete.yml
+++ b/roles/azure_manage_resource_group/tasks/delete.yml
@@ -16,6 +16,11 @@
         resource_group: "{{ azure_manage_resource_group_name }}"
       with_items: "{{ result.locks }}"
 
+- name: Sleep for 10 seconds and continue with play
+  ansible.builtin.wait_for:
+    timeout: 10
+  delegate_to: localhost
+
 - name: Delete resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ azure_manage_resource_group_name }}"


### PR DESCRIPTION
Add a timeout (as a temporary solution) in the delete task of the azure_manage_resource_group role.
Fix for this bug - https://issues.redhat.com/browse/ACA-1498

In the future we should consider backoff logic (retries) in the delete code.

<img width="1260" alt="Screenshot 2024-05-16 at 16 20 03" src="https://github.com/redhat-cop/cloud.azure_ops/assets/58551443/37c58009-969f-42d1-8f1e-52101ed37dce">
