### PR TITLE
Add retries to Resource Group deletion

### DIFF
--- a/changelogs/fragments/20240521-azure_resource_groups_delete.yml
+++ b/changelogs/fragments/20240521-azure_resource_groups_delete.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Added retries to Resource Group deletion (retries=40, delay=5)

--- a/roles/azure_manage_resource_group/tasks/delete.yml
+++ b/roles/azure_manage_resource_group/tasks/delete.yml
@@ -16,13 +16,12 @@
         resource_group: "{{ azure_manage_resource_group_name }}"
       with_items: "{{ result.locks }}"
 
-- name: Sleep for 10 seconds and continue with play
-  ansible.builtin.wait_for:
-    timeout: 10
-  delegate_to: localhost
-
 - name: Delete resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ azure_manage_resource_group_name }}"
     state: absent
     force_delete_nonempty: "{{ azure_manage_resource_group_force_delete_nonempty | default(omit) }}"
+  retries: 40
+  delay: 5
+  register: result
+  until: result.failed == false


### PR DESCRIPTION
In some cases, the resource group can't be deleted immediately. 
We need to wait until all resources inside it are completely destroyed. 
Add retries with a 5-second delay, with a maximum of 40 retries.