### PR TITLE
Bug fixes of the azure roles

### DIFF
--- a/changelogs/fragments/20240613-bug_fixes.yaml
+++ b/changelogs/fragments/20240613-bug_fixes.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - Added missed argument to the 'Power On VM' task in azure_virtual_machine_with_public_ip role
+  - Updated README with proper role's variables description for azure_virtual_machine_with_public_ip role
+  - Fixed undefined variables issue for azure_virtual_machine_with_public_ip role
+  - Fixed azure_manage_resource_group_tags value for new resource group creation by role

--- a/roles/azure_load_balancer_with_public_ip/tasks/create.yml
+++ b/roles/azure_load_balancer_with_public_ip/tasks/create.yml
@@ -13,7 +13,7 @@
     azure_manage_resource_group_operation: create
     azure_manage_resource_group_name: "{{ azure_load_balancer_with_public_ip_resource_group }}"
     azure_manage_resource_group_region: "{{ azure_load_balancer_with_public_ip_region }}"
-    azure_manage_resource_group_tags: "{{ azure_load_balancer_with_public_ip_tags | default(omit) }}"
+    azure_manage_resource_group_tags: "{{ azure_load_balancer_with_public_ip_tags | default({}) }}"
   when: rg_info.resourcegroups | length == 0
 
 - name: Ensure public ip exists

--- a/roles/azure_manage_networking_stack/tasks/create.yml
+++ b/roles/azure_manage_networking_stack/tasks/create.yml
@@ -33,7 +33,7 @@
     azure_manage_resource_group_operation: create
     azure_manage_resource_group_name: "{{ azure_manage_networking_stack_resource_group }}"
     azure_manage_resource_group_region: "{{ azure_manage_networking_stack_region }}"
-    azure_manage_resource_group_tags: "{{ azure_manage_networking_stack_tags | default(omit) }}"
+    azure_manage_resource_group_tags: "{{ azure_manage_networking_stack_tags | default({}) }}"
   when: rg_info.resourcegroups | length == 0
 
 - name: Create azure virtual network

--- a/roles/azure_manage_postgresql/tasks/create.yml
+++ b/roles/azure_manage_postgresql/tasks/create.yml
@@ -27,7 +27,7 @@
     azure_manage_resource_group_operation: create
     azure_manage_resource_group_name: "{{ azure_manage_postgresql_resource_group }}"
     azure_manage_resource_group_region: "{{ azure_manage_postgresql_region }}"
-    azure_manage_resource_group_tags: "{{ azure_manage_postgresql_tags | default(omit) }}"
+    azure_manage_resource_group_tags: "{{ azure_manage_postgresql_tags | default({}) }}"
   when: rg_info.resourcegroups | length == 0
 
 - name: Check Azure PostgreSQL server restore point

--- a/roles/azure_virtual_machine_with_public_ip/README.md
+++ b/roles/azure_virtual_machine_with_public_ip/README.md
@@ -15,21 +15,22 @@ Role Variables
 * **azure_virtual_machine_with_public_ip_remove_on_absent**: Specify which resources to remove when `azure_virtual_machine_with_public_ip_operation='delete'`. 'all' removes all resources attached to the VM being removed; 'all_autocreated' removes the resources that were automatically created while provisioning the VM (public ip, network interface, security group). To remove only specific resources, use the values 'network_interfaces', 'virtual_storage', or 'public_ips'. The default value is 'all'.
 * **azure_virtual_machine_with_public_ip_resource_group**: Resource group on/from which the virtual machine will reside. When `azure_virtual_machine_with_public_ip_operation='create'`, this resource group will be created if it does not exist.
 * **azure_virtual_machine_with_public_ip_region**: An Azure location for the resources.
-* **azure_virtual_machine_with_public_ip_tags**: Dictionary of string:string pairs to assign as metadata to the resource group.
+* **azure_virtual_machine_with_public_ip_tags**: Dictionary of string:string pairs to assign as metadata to the VM.
 * **azure_virtual_machine_with_public_ip_vm**: Object used to provide details for a virtual machine. Contains the following:
   - **name**: (Required) Name of the virtual machine.
   - **admin_username**: Administrator's login name of a server. Required for creation.
-  - **admin_password**: Password of the administrator login. Not required when `os='Linux'` and `ssh_pw_enabled='false'`.
+  - **admin_password**: Password of the administrator login. Not required when `os='Linux'` and `ssh_pw_enabled='false'`. The supplied password must be between 6-72 characters long, control characters are not allowed, and must satisfy at least 3 of password complexity requirements from the following: Contains an uppercase character; Contains a lowercase character; Contains a numeric digit; Contains a special character. 
   - **size**: Valid Azure VM size. Choices vary depending on the subscription and location.
   - **network_interfaces**: List of network interfaces to add to the VM. Can be a string of name or resource ID of the network interface, can also be a dict containing 'resource_group' and 'name' of the network interface. A default network interface will be created if not provided.
   - **vnet_address_prefixes_cidr**: List of IPv4 address ranges for virtual network where each is formatted using CIDR notation.
   Required when creating a new virtual network, otherways should be omitted
   - **subnet_address_prefixes_cidr**: CIDR defining the IPv4 and IPv6 address space of the subnet.
   Required when creating a new virtual network, otherways should be omitted
+  - **load_balancer_backend_address_pools**: List of existing load balancer backend address pools in which the network interface will be load balanced.
   - **os**: Type of Operating System. Default is 'Linux'
-  - **availability_set**: Name or ID of existing availability set to add the VM to.
   - **image**: The image used to build the VM. For custom images, the name of the image. To narrow the search to a specific resource group, a dict with the keys name and resource_group. For Marketplace images, a dict with the keys publisher, offer, sku, and version. Set version=latest to get the most recent version of a given image.
-  - **ssh_pw_enabled**: Enable/disable SSH passwords. Valid values are 'yes', 'no'. Default value is 'yes'.
+  - **ssh_pw_enabled**: Enable/disable SSH passwords. Valid values are 'true', 'false'. When `os='Linux'` and  `ssh_pw_enabled='false'` requires the use of SSH keys.
+  Default value is 'true'.
   - **ssh_public_keys**: List of SSH keys when `os='Linux'`. Accepts a list of dicts where each dictionary contains two keys, 'path' and 'key_data'. Set path to the default location of the authorized_keys files. For example, path=/home/<admin username>/.ssh/authorized_keys. Set key_data to the actual value of the public key.
   - **data_disks**: List of data disks.
     - **lun**: Logical unit number for data disk. Must be unique for each data disk attached to a VM.
@@ -39,7 +40,8 @@ Role Variables
     - **storage_account_name**: Name of an existing storage account that supports creation of VHD blobs.
     - **storage_blob_name**: Name of storage blob used to hold the OS disk image of the VM.
     - **storage_container_name**: Name of the container to use within the storage account to store VHD blobs. Default is 'vhds'
-* **azure_virtual_machine_with_public_ip_availability_set**: Object used to provide details for an availability set to be used by a VM. Contains the following:
+* **azure_virtual_machine_with_public_ip_availability_set**: Object used to provide details for an availability set to be used by a VM. Will be created if availability set doesn't exist. May be omitted.
+Contains the following:
   - **name**: (Required) Name of the availability set.
   - **platform_fault_domain_count**: Fault domains define the group of virtual machines that share a common power source and network switch. Should be between 1 and 3.
   - **platform_update_domain_count**: Update domains indicate groups of virtual machines and underlying physical hardware that can be rebooted at the same time.

--- a/roles/azure_virtual_machine_with_public_ip/tasks/create.yml
+++ b/roles/azure_virtual_machine_with_public_ip/tasks/create.yml
@@ -32,6 +32,11 @@
     azure_manage_resource_group_tags: "{{ azure_virtual_machine_with_public_ip_tags | default(omit) }}"
   when: rg_info.resourcegroups | length == 0
 
+# Set tags for VM
+- name: Set tags for VM
+  ansible.builtin.set_fact:
+    vm_tags: "{{ azure_virtual_machine_with_public_ip_tags | default({}) }}"
+
 # If nic is not specified, create virtual network if needed and create default public ip & nic
 - name: Ensure default nic and default public ip
   when: azure_virtual_machine_with_public_ip_vm.network_interfaces is undefined
@@ -96,16 +101,27 @@
 
     - name: Tag all autocreated resources for cleanup
       ansible.builtin.set_fact:
-        vm_tags: "{{ azure_virtual_machine_with_public_ip_tags | default({}) | combine({'_own_pip_': vm_name}, {'_own_nic_': vm_name}, {'_own_nsg_': vm_name}) }}"
+        vm_tags: "{{ vm_tags | combine({'_own_pip_': vm_name}, {'_own_nic_': vm_name}, {'_own_nsg_': vm_name}) }}"
 
-# Create/update availability set
+# Create availability set if doesn't exist
+- name: Get availability set info
+  azure.azcollection.azure_rm_availabilityset_info:
+    resource_group: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
+    name: "{{ azure_virtual_machine_with_public_ip_availability_set.name }}"
+  register: aset_info
+  when: azure_virtual_machine_with_public_ip_availability_set is defined
+
 - name: Create availability set
   azure.azcollection.azure_rm_availabilityset:
     resource_group: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
-    name: "{{ azure_availability_set.name }}"
-    platform_update_domain_count: "{{ azure_availability_set.platform_update_domain_count | default(omit) }}"
-    platform_fault_domain_count: "{{ azure_availability_set.platform_fault_domain_count | default(omit) }}"
-  when: azure_availability_set is defined
+    name: "{{ azure_virtual_machine_with_public_ip_availability_set.name }}"
+    platform_update_domain_count: "{{ azure_virtual_machine_with_public_ip_availability_set.platform_update_domain_count | default(omit) }}"
+    platform_fault_domain_count: "{{ azure_virtual_machine_with_public_ip_availability_set.platform_fault_domain_count | default(omit) }}"
+    tags:
+      _own_availability_set_: "{{ azure_virtual_machine_with_public_ip_availability_set.name }}"
+  when:
+    - azure_virtual_machine_with_public_ip_availability_set is defined
+    - aset_info.ansible_info.azure_availabilitysets | length == 0
 
 # Create/update VM
 - name: Create/Update VM
@@ -115,7 +131,7 @@
     vm_size: "{{ azure_virtual_machine_with_public_ip_vm.size | default(omit) }}"
     network_interfaces: "{{ azure_virtual_machine_with_public_ip_vm.network_interfaces | default(vm_name) }}"
     os_type: "{{ azure_virtual_machine_with_public_ip_vm.os | default(omit) }}"
-    availability_set: "{{ azure_virtual_machine_with_public_ip_vm.availability_set | default(omit) }}"
+    availability_set: "{{ azure_virtual_machine_with_public_ip_availability_set.name | default(omit) }}"
     image: "{{ azure_virtual_machine_with_public_ip_vm.image | default(omit) }}"
     admin_username: "{{ azure_virtual_machine_with_public_ip_vm.admin_username | default(omit) }}"
     admin_password: "{{ azure_virtual_machine_with_public_ip_vm.admin_password | default(omit) }}"

--- a/roles/azure_virtual_machine_with_public_ip/tasks/create.yml
+++ b/roles/azure_virtual_machine_with_public_ip/tasks/create.yml
@@ -29,7 +29,7 @@
     azure_manage_resource_group_operation: create
     azure_manage_resource_group_name: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
     azure_manage_resource_group_region: "{{ azure_virtual_machine_with_public_ip_region }}"
-    azure_manage_resource_group_tags: "{{ azure_virtual_machine_with_public_ip_tags | default(omit) }}"
+    azure_manage_resource_group_tags: "{{ azure_virtual_machine_with_public_ip_tags | default({}) }}"
   when: rg_info.resourcegroups | length == 0
 
 # Set tags for VM

--- a/roles/azure_virtual_machine_with_public_ip/tasks/delete.yml
+++ b/roles/azure_virtual_machine_with_public_ip/tasks/delete.yml
@@ -11,6 +11,26 @@
     remove_on_absent: "{{ azure_virtual_machine_with_public_ip_remove_on_absent | default(omit) }}"
     state: absent
 
+# Delete availability set if created by role
+- name: Get availability set info
+  azure.azcollection.azure_rm_availabilityset_info:
+    resource_group: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
+    name: "{{ azure_virtual_machine_with_public_ip_availability_set.name }}"
+    tags:
+      _own_availability_set_
+  register: _aset_info
+  when: azure_virtual_machine_with_public_ip_availability_set is defined
+
+- name: Delete availability set if created by role
+  azure.azcollection.azure_rm_availabilityset:
+    resource_group: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
+    name: "{{ azure_virtual_machine_with_public_ip_availability_set.name }}" 
+    state: absent
+  when:
+    - azure_virtual_machine_with_public_ip_availability_set is defined
+    - _aset_info.ansible_info.azure_availabilitysets | length == 1
+    - azure_virtual_machine_with_public_ip_remove_on_absent in ['all', 'all_autocreated']
+
 # Delete Virtual network if created by role
 - name: Get virtual network info
   azure.azcollection.azure_rm_virtualnetwork_info:

--- a/roles/azure_virtual_machine_with_public_ip/tasks/main.yml
+++ b/roles/azure_virtual_machine_with_public_ip/tasks/main.yml
@@ -33,6 +33,7 @@
   azure.azcollection.azure_rm_virtualmachine:
     resource_group: "{{ azure_virtual_machine_with_public_ip_resource_group }}"
     name: "{{ vm_name }}"
+    started: true
   when: azure_virtual_machine_with_public_ip_operation == 'power_on'
 
 - name: Restart VM


### PR DESCRIPTION
Changes:
  - [ACA-1634](https://issues.redhat.com/browse/ACA-1634): Added missed argument 'started: true' to the 'Power On VM' task in azure_virtual_machine_with_public_ip role
  - [ACA-1580](https://issues.redhat.com/browse/ACA-1580): Updated README with proper role's variables description for azure_virtual_machine_with_public_ip role
  - [ACA-1633](https://issues.redhat.com/browse/ACA-1633): Fixed undefined variables issue for azure_virtual_machine_with_public_ip role
  - [ACA-1635](https://issues.redhat.com/browse/ACA-1635): Fixed azure_manage_resource_group_tags value for the new resource group creation by role