### PR TITLE
Added integration test for  azure_manage_postgresql role

### DIFF
--- a/changelogs/fragments/20240617-azure_manage_postgresql_create.yml
+++ b/changelogs/fragments/20240617-azure_manage_postgresql_create.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Removed the undefined variables from the create.yml of azure_manage_postgresql role and 
+    replaced them with defined ones.

--- a/roles/azure_manage_postgresql/tasks/create.yml
+++ b/roles/azure_manage_postgresql/tasks/create.yml
@@ -64,7 +64,7 @@
     value: "{{ item.value }}"
   with_items: "{{ azure_manage_postgresql_postgresql_settings }}"
   when:
-    - azure_postgresql_settings | length > 0
+    - azure_manage_postgresql_postgresql_settings | length > 0
 
 - name: Update PostgreSQL Server Firewall rules
   azure.azcollection.azure_rm_postgresqlfirewallrule:
@@ -75,7 +75,7 @@
     end_ip_address: "{{ item.end_ip_address }}"
   with_items: "{{ azure_manage_postgresql_postgresql_firewall_rules }}"
   when:
-    - azure_postgresql_firewall_rules | length > 0
+    - azure_manage_postgresql_postgresql_firewall_rules | length > 0
 
 - name: Create/Update PostgreSQL Database instances
   azure.azcollection.azure_rm_postgresqldatabase:
@@ -87,4 +87,4 @@
     force_update: "{{ item.force | default(omit) }}"
   with_items: "{{ azure_manage_postgresql_postgresql_database_instances }}"
   when:
-    - azure_postgresql_database_instances | length > 0
+    - azure_manage_postgresql_postgresql_database_instances | length > 0

--- a/tests/integration/targets/test_azure_manage_postgresql/aliases
+++ b/tests/integration/targets/test_azure_manage_postgresql/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+role/azure_manage_postgresql
+time=2m

--- a/tests/integration/targets/test_azure_manage_postgresql/defaults/main.yml
+++ b/tests/integration/targets/test_azure_manage_postgresql/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+azure_manage_postgresql_postgresql_name: "{{ resource_prefix }}-postgresql-server"
+azure_manage_postgresql_postgresql_admin_username: "ansible"
+azure_manage_postgresql_postgresql_admin_password: "A!1b#2C$d%3E&4f*5G-6h+7I_8j(9K)0l"
+azure_manage_postgresql_postgresql_sku:
+  name: "B_Gen5_1"
+  tier: "Basic"
+azure_manage_postgresql_postgresql_storage_mb: 5120
+azure_manage_postgresql_postgresql_backup_retention_days: 10

--- a/tests/integration/targets/test_azure_manage_postgresql/tasks/create_and_delete_postgresql.yml
+++ b/tests/integration/targets/test_azure_manage_postgresql/tasks/create_and_delete_postgresql.yml
@@ -1,0 +1,118 @@
+---
+- name: Test Create and Delete PostgreSQL Server
+  block:
+    - name: Print test step details
+      ansible.builtin.debug:
+        msg: "Run test with resource_group={{ test_resource_group }}"
+
+    - name: Set vars for test
+      ansible.builtin.set_fact:
+        azure_manage_postgresql_postgresql_version: "9.6"
+        azure_manage_postgresql_postgresql_firewall_rules:
+          - name: "rule_0"
+            start_ip_address: "172.10.1.0"
+            end_ip_address: "172.10.128.0"
+        azure_manage_postgresql_postgresql_database_instances:
+          - name: "database-test"
+
+    # Test: Create PostgreSQL Server
+    - name: Create PostgreSQL Server
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_postgresql
+      vars:
+        azure_manage_postgresql_operation: create
+        azure_manage_postgresql_resource_group: "{{ test_resource_group }}"
+    
+    # Verify that PostgreSQL Server was created as expected
+    - name: Gather PostgreSQL Server info
+      azure.azcollection.azure_rm_postgresqlserver_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_postgresql_postgresql_name }}"
+      register: _postgresql
+
+    - name: Assert that PostgreSQL Server was created as expected
+      ansible.builtin.assert:
+        that:
+          - _postgresql.servers | length == 1
+          - _postgresql.servers[0].name == azure_manage_postgresql_postgresql_name
+          - _postgresql.servers[0].location == azure_manage_postgresql_region
+          - _postgresql.servers[0].sku.name == azure_manage_postgresql_postgresql_sku.name
+          - _postgresql.servers[0].sku.tier == azure_manage_postgresql_postgresql_sku.tier
+          - _postgresql.servers[0].storage_mb == azure_manage_postgresql_postgresql_storage_mb
+          - _postgresql.servers[0].admin_username == azure_manage_postgresql_postgresql_admin_username
+          - _postgresql.servers[0].version == azure_manage_postgresql_postgresql_version
+
+    # Verify that PostgreSQL Server firewall rule was created as expected
+    - name: Gather PostgreSQL Server firewall rule info  
+      azure.azcollection.azure_rm_postgresqlfirewallrule_info:
+        resource_group: "{{ test_resource_group }}"
+        server_name: "{{ azure_manage_postgresql_postgresql_name }}"
+        name: "{{ azure_manage_postgresql_postgresql_firewall_rules[0].name }}"
+      register: _postgresql_firewall_rule
+
+    - name: Assert that PostgreSQL Server firewall rules were created as expected
+      ansible.builtin.assert:
+        that:
+          - _postgresql_firewall_rule.rules | length == 1
+          - _postgresql_firewall_rule.rules[0].server_name == azure_manage_postgresql_postgresql_name
+          - _postgresql_firewall_rule.rules[0].name == azure_manage_postgresql_postgresql_firewall_rules[0].name
+          - _postgresql_firewall_rule.rules[0].start_ip_address == azure_manage_postgresql_postgresql_firewall_rules[0].start_ip_address
+          - _postgresql_firewall_rule.rules[0].end_ip_address == azure_manage_postgresql_postgresql_firewall_rules[0].end_ip_address
+
+    # Verify that PostgreSQL Database Instance was created as expected
+    - name: Gather PostgreSQL Database Instance info  
+      azure.azcollection.azure_rm_postgresqldatabase_info:
+        resource_group: "{{ test_resource_group }}"
+        server_name: "{{ azure_manage_postgresql_postgresql_name }}"
+        name: "{{ azure_manage_postgresql_postgresql_database_instances[0].name }}"
+      register: _postgresql_database
+
+    - name: Assert that PostgreSQL Database Instance was created as expected
+      ansible.builtin.assert:
+        that:
+          - _postgresql_database.databases | length == 1
+          - _postgresql_database.databases[0].server_name == azure_manage_postgresql_postgresql_name
+          - _postgresql_database.databases[0].name == azure_manage_postgresql_postgresql_database_instances[0].name
+
+    # Test: Delete PostgreSQL Server
+    - name: Delete PostgreSQL Server
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_postgresql
+      vars:
+        azure_manage_postgresql_operation: delete
+        azure_manage_postgresql_resource_group: "{{ test_resource_group }}"
+        azure_manage_postgresql_delete_server: true
+
+    # Verify that PostgreSQL Server was deleted
+    - name: Ensure PostgreSQL Server was deleted
+      azure.azcollection.azure_rm_postgresqlserver_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_postgresql_postgresql_name }}"
+      register: _postgresql
+      failed_when: _postgresql.servers | length > 0
+
+    # Verify that PostgreSQL Firewall rules were deleted
+    - name: Ensure PostgreSQL Firewall rules were deleted
+      azure.azcollection.azure_rm_postgresqlfirewallrule_info:
+        resource_group: "{{ test_resource_group }}"
+        server_name: "{{ azure_manage_postgresql_postgresql_name }}"
+        name: "{{ azure_manage_postgresql_postgresql_firewall_rules[0].name }}"
+      register: _postgresql_firewall_rule
+      failed_when: _postgresql_firewall_rule.rules | length > 0
+
+    # Verify that PostgreSQL database instance was deleted
+    - name: Ensure PostgreSQL database instance was deleted
+      azure.azcollection.azure_rm_postgresqldatabase_info:
+        resource_group: "{{ test_resource_group }}"
+        server_name: "{{ azure_manage_postgresql_postgresql_name }}"
+        name: "{{ azure_manage_postgresql_postgresql_database_instances[0].name }}"
+      register: _postgresql_database
+      failed_when: _postgresql_database.databases | length > 0
+
+    # Verify that Resource Group was deleted, if requiered
+    - name: Ensure Resource Group was deleted - {{ test_resource_group }}
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ test_resource_group }}"
+      when: azure_manage_postgresql_resource_group is defined and azure_manage_postgresql_delete_resource_group
+      register: _resourcegroup
+      failed_when: _resourcegroup.resourcegroups | length > 0

--- a/tests/integration/targets/test_azure_manage_postgresql/tasks/main.yml
+++ b/tests/integration/targets/test_azure_manage_postgresql/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+# Determine Azure Region
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+# Test: Create and Delete postgresql server with pre-created Resource Group
+- name: Test with pre-created Resource Group
+  block:
+    - name: Run tests with pre-created Resource Group
+      ansible.builtin.include_tasks: create_and_delete_postgresql.yml
+      vars:
+        test_resource_group: "{{ resource_group }}"
+        azure_manage_postgresql_region: "{{ __rg_info.resourcegroups.0.location }}"
+
+  always:
+    - name: Always - Gather PostgreSQL Server info
+      azure.azcollection.azure_rm_postgresqlserver_info:
+        resource_group: "{{ resource_group }}"
+        name: "{{ azure_manage_postgresql_postgresql_name }}"
+      register: _postgresql
+
+    - name: Cleanup - Delete a PostgreSQL Server, resource_group={{ resource_group }}
+      azure.azcollection.azure_rm_postgresqlserver:
+        resource_group: "{{ resource_group }}"
+        name: "{{ azure_manage_postgresql_postgresql_name }}"
+        state: absent
+      when: _postgresql.servers | length > 0  
+        
+# Test: Create and Delete postgresql server with new Resource Group
+- name: Test with create and delete Resource Group
+  block:
+    - name: Generate new resource group name
+      ansible.builtin.set_fact:
+        new_resource_group: "{{ resource_prefix }}-{{ resource_group }}"
+
+    - name: Validate resource group doesn't exist before test - {{ new_resource_group }}
+      azure.azcollection.azure_rm_resourcegroup_info:
+        name: "{{ new_resource_group }}"
+      register: _resourcegroup
+      failed_when: _resourcegroup.resourcegroups | length > 0
+
+    - name: Test with create and delete Resource Group
+      ansible.builtin.include_tasks: create_and_delete_postgresql.yml
+      vars:
+        test_resource_group: "{{ new_resource_group }}"
+        azure_manage_postgresql_region: "{{ __rg_info.resourcegroups.0.location }}"
+        azure_manage_postgresql_delete_resource_group: true
+
+  always:
+    - name: Always - Cleanup - Delete a Resource group including resources it contains - {{ new_resource_group }}
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ new_resource_group }}"
+        force_delete_nonempty: true
+        state: absent


### PR DESCRIPTION
Added integration test for  azure_manage_postgresql role.
Two scenarios tested:
1. Test azure_manage_postgresql role with pre-created Resource group
2. Test azure_manage_postgresql role with create/delete Resource group option

Fixed bug:
1. Fixed undefined vars in the create.yml file of azure_manage_postgresql role (https://issues.redhat.com/browse/ACA-1599)