### PR TITLE
Generate random password instead of hardcoded

### DIFF
--- a/tests/integration/targets/test_azure_manage_postgresql/defaults/main.yml
+++ b/tests/integration/targets/test_azure_manage_postgresql/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 azure_manage_postgresql_postgresql_name: "{{ resource_prefix }}-postgresql-server"
 azure_manage_postgresql_postgresql_admin_username: "ansible"
-azure_manage_postgresql_postgresql_admin_password: "A!1b#2C$d%3E&4f*5G-6h+7I_8j(9K)0l"
 azure_manage_postgresql_postgresql_sku:
   name: "B_Gen5_1"
   tier: "Basic"

--- a/tests/integration/targets/test_azure_manage_postgresql/tasks/main.yml
+++ b/tests/integration/targets/test_azure_manage_postgresql/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Generate Admin Password
+  ansible.builtin.set_fact:
+    azure_manage_postgresql_postgresql_admin_password: lookup('community.general.random_string', length=6, min_lower=1, min_upper=1, min_numeric=1, min_special=1)
+  when: azure_manage_postgresql_postgresql_admin_password is not defined
+
 # Determine Azure Region
 - name: Gather Resource Group info
   azure.azcollection.azure_rm_resourcegroup_info:


### PR DESCRIPTION
This change is done in order to avoid having hardcoded "password like" string in the repository.
Avoid "Potential data leak" reports from security reviewing service