### PR TITLE
ACA-1515 Updating retries count to be 20 from 40

### DIFF
--- a/changelogs/fragments/20240814-azure_manage_resurce_group.yml
+++ b/changelogs/fragments/20240814-azure_manage_resurce_group.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Updating retries count to be 20 from 40 in the Delete resource group task in order to shorten the time the user waits before the task fails

--- a/roles/azure_manage_resource_group/tasks/delete.yml
+++ b/roles/azure_manage_resource_group/tasks/delete.yml
@@ -21,7 +21,7 @@
     name: "{{ azure_manage_resource_group_name }}"
     state: absent
     force_delete_nonempty: "{{ azure_manage_resource_group_force_delete_nonempty | default(omit) }}"
-  retries: 40
+  retries: 20
   delay: 5
   register: result
   until: result.failed == false


### PR DESCRIPTION
 Updating retries count to be 20 from 40 in the Delete resource group task in order to shorten the time the user waits before the task fails