### PR TITLE
feat: RAG pipeline reference architecture with Azure AI Search and OpenAI

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ tags:
   - azure
   - infrastructure
 dependencies:
-  azure.azcollection: ">=3.3.0"
+  azure.azcollection: ">=3.9.0"
   ansible.windows: ">=3.2.0"
   community.general: ">=11.2.1"
 build_ignore:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'

--- a/playbooks/RAG_PIPELINE.md
+++ b/playbooks/RAG_PIPELINE.md
@@ -54,7 +54,7 @@ Variables
 * **azure_openai_embedding_deployment_name**: Deployment name for the embedding model. Default: `embedding-deployment`
 * **azure_openai_embedding_capacity**: Capacity units for the embedding deployment. Default: `1`
 * **azure_openai_chat_model**: Chat completion model name. Default: `gpt-4o`
-* **azure_openai_chat_model_version**: Chat model version. Default: `2024-08-06`
+* **azure_openai_chat_model_version**: Chat model version. Default: `2024-11-20`
 * **azure_openai_chat_deployment_name**: Deployment name for the chat model. Default: `chat-deployment`
 * **azure_openai_chat_capacity**: Capacity units for the chat deployment. Default: `1`
 

--- a/playbooks/RAG_PIPELINE.md
+++ b/playbooks/RAG_PIPELINE.md
@@ -1,0 +1,102 @@
+## cloud.azure_ops.rag_pipeline playbook
+
+A playbook to deploy a RAG (Retrieval-Augmented Generation) pipeline on Azure using Azure AI Search and Azure OpenAI.
+
+This reference architecture automates the full RAG stack: storage for source documents, Azure AI Search for indexing and retrieval, and Azure OpenAI for embeddings and chat completion.
+
+### Use Cases
+
+* **Enterprise knowledge base** — Index internal documents and serve answers via Azure OpenAI
+* **Customer support automation** — Search product documentation and generate contextual responses
+* **Compliance document Q&A** — Query regulatory documents with retrieval-augmented generation
+
+### Prerequisites
+
+* Azure subscription with sufficient quota
+* `azure.azcollection` >= 3.9.0 installed
+* Azure credentials configured (service principal, managed identity, or CLI auth)
+* The following Azure resource providers must be registered on the subscription:
+  - `Microsoft.Storage`
+  - `Microsoft.Search`
+  - `Microsoft.CognitiveServices`
+
+Variables
+--------------
+
+###### Common
+--------------
+
+* **azure_resource_group**: (Required) Resource group for the RAG pipeline resources.
+* **azure_region**: An Azure location for the resources. Default: `eastus`
+* **operation**: Operation to perform. Valid values are `create`, `delete`. Default: `create`
+
+--------------
+###### Storage
+--------------
+
+* **azure_storage_account_name**: Name of the storage account. Default: `{{ azure_resource_group | regex_replace('[^a-z0-9]', '') }}storage`
+* **azure_storage_container_name**: Name of the blob container for documents. Default: `documents`
+
+--------------
+###### AI Search
+--------------
+
+* **azure_ai_search_name**: Name of the AI Search service. Default: `{{ azure_resource_group }}-search`
+* **azure_ai_search_sku**: Pricing tier for AI Search. Default: `basic`
+
+--------------
+###### OpenAI
+--------------
+
+* **azure_openai_account_name**: Name of the Azure OpenAI account. Default: `{{ azure_resource_group }}-openai`
+* **azure_openai_embedding_model**: Embedding model name. Default: `text-embedding-ada-002`
+* **azure_openai_embedding_model_version**: Embedding model version. Default: `2`
+* **azure_openai_embedding_deployment_name**: Deployment name for the embedding model. Default: `embedding-deployment`
+* **azure_openai_embedding_capacity**: Capacity units for the embedding deployment. Default: `1`
+* **azure_openai_chat_model**: Chat completion model name. Default: `gpt-4o`
+* **azure_openai_chat_model_version**: Chat model version. Default: `2024-08-06`
+* **azure_openai_chat_deployment_name**: Deployment name for the chat model. Default: `chat-deployment`
+* **azure_openai_chat_capacity**: Capacity units for the chat deployment. Default: `1`
+
+--------------
+###### Search Index
+--------------
+
+* **azure_ai_search_index_name**: Name of the search index. Default: `rag-index`
+* **azure_ai_search_datasource_name**: Name of the data source connection. Default: `rag-datasource`
+* **azure_ai_search_indexer_name**: Name of the indexer. Default: `rag-indexer`
+* **azure_ai_search_skillset_name**: Name of the skillset. Default: `rag-skillset`
+
+### Usage
+
+#### Create RAG Pipeline
+
+```bash
+ansible-playbook cloud.azure_ops.rag_pipeline \
+  -e azure_resource_group=my-rag-rg \
+  -e azure_region=eastus
+```
+
+#### Delete RAG Pipeline
+
+```bash
+ansible-playbook cloud.azure_ops.rag_pipeline \
+  -e azure_resource_group=my-rag-rg \
+  -e operation=delete
+```
+
+### Security Best Practices
+
+The playbook deploys with system-assigned managed identity enabled on AI Search and OpenAI for demo simplicity. For production deployments, consider:
+
+* **RBAC Role Assignments**: Assign `Storage Blob Data Reader` to the AI Search managed identity on the storage account. Assign `Cognitive Services OpenAI User` to the AI Search managed identity on the OpenAI account. This eliminates the need for connection strings and API keys.
+* **Private Endpoints**: Replace public network access with private endpoints for AI Search, OpenAI, and Storage Account. Create private DNS zones for each service.
+* **Network Isolation**: Deploy AI Search and OpenAI into a VNet using private endpoints. Restrict storage account access to the VNet.
+* **Key Vault Integration**: Store any required API keys or connection strings in Azure Key Vault rather than in playbook variables.
+
+### Troubleshooting
+
+* **Quota errors on OpenAI deployments**: Check your subscription's Cognitive Services quota for the target region. Request increases via the Azure portal.
+* **AI Search provisioning slow**: The `basic` tier can take 5-10 minutes to provision. The playbook will wait for completion.
+* **Indexer failures**: After deployment, check the indexer status in the Azure portal. Common issues include missing documents in the blob container or incorrect storage connection strings.
+* **Model not available in region**: Not all OpenAI models are available in all regions. Check Azure OpenAI model availability for your target region.

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -288,7 +288,7 @@
           ansible.builtin.set_fact:
             _search_admin_key: "{{ _search_keys.response.primaryKey }}"
           no_log: true
-          when: _search_keys is succeeded
+          when: _search_keys.response.primaryKey is defined
 
         - name: Delete search indexer
           ansible.builtin.uri:
@@ -297,7 +297,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
-          when: _search_keys is succeeded
+          when: _search_admin_key is defined
           register: _delete_indexer
           failed_when: false
 
@@ -308,7 +308,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
-          when: _search_keys is succeeded
+          when: _search_admin_key is defined
           register: _delete_skillset
           failed_when: false
 
@@ -319,7 +319,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
-          when: _search_keys is succeeded
+          when: _search_admin_key is defined
           register: _delete_index
           failed_when: false
 
@@ -330,7 +330,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
-          when: _search_keys is succeeded
+          when: _search_admin_key is defined
           register: _delete_datasource
           failed_when: false
 

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -282,7 +282,7 @@
             method: POST
           register: _search_keys
           no_log: true
-          ignore_errors: true
+          failed_when: false
 
         - name: Set search admin key fact
           ansible.builtin.set_fact:
@@ -298,7 +298,8 @@
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
           when: _search_keys is succeeded
-          ignore_errors: true
+          register: _delete_indexer
+          failed_when: false
 
         - name: Delete search skillset
           ansible.builtin.uri:
@@ -308,7 +309,8 @@
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
           when: _search_keys is succeeded
-          ignore_errors: true
+          register: _delete_skillset
+          failed_when: false
 
         - name: Delete search index
           ansible.builtin.uri:
@@ -318,7 +320,8 @@
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
           when: _search_keys is succeeded
-          ignore_errors: true
+          register: _delete_index
+          failed_when: false
 
         - name: Delete search data source
           ansible.builtin.uri:
@@ -328,7 +331,8 @@
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
           when: _search_keys is succeeded
-          ignore_errors: true
+          register: _delete_datasource
+          failed_when: false
 
         - name: Delete embedding model deployment
           azure.azcollection.azure_rm_resource:
@@ -341,7 +345,8 @@
                 name: "{{ azure_openai_embedding_deployment_name }}"
             api_version: "2024-10-01"
             state: absent
-          ignore_errors: true
+          register: _delete_embedding
+          failed_when: false
 
         - name: Delete chat model deployment
           azure.azcollection.azure_rm_resource:
@@ -354,7 +359,8 @@
                 name: "{{ azure_openai_chat_deployment_name }}"
             api_version: "2024-10-01"
             state: absent
-          ignore_errors: true
+          register: _delete_chat
+          failed_when: false
 
         - name: Delete OpenAI account
           ansible.builtin.include_role:

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -198,6 +198,7 @@
                       prioritizedContentFields:
                         - fieldName: content
             status_code: [200, 201, 204]
+          no_log: true
 
         - name: Create search skillset
           ansible.builtin.uri:
@@ -225,6 +226,7 @@
                     - name: embedding
                       targetName: content_vector
             status_code: [200, 201, 204]
+          no_log: true
 
         - name: Create search indexer
           ansible.builtin.uri:
@@ -256,6 +258,7 @@
                 - sourceFieldName: /document/content_vector
                   targetFieldName: content_vector
             status_code: [200, 201, 204]
+          no_log: true
 
         # Phase 4 - Output
         - name: Display RAG pipeline endpoints
@@ -300,6 +303,7 @@
           when: _search_admin_key is defined
           register: _delete_indexer
           failed_when: false
+          no_log: true
 
         - name: Delete search skillset
           ansible.builtin.uri:
@@ -311,6 +315,7 @@
           when: _search_admin_key is defined
           register: _delete_skillset
           failed_when: false
+          no_log: true
 
         - name: Delete search index
           ansible.builtin.uri:
@@ -322,6 +327,7 @@
           when: _search_admin_key is defined
           register: _delete_index
           failed_when: false
+          no_log: true
 
         - name: Delete search data source
           ansible.builtin.uri:
@@ -333,6 +339,7 @@
           when: _search_admin_key is defined
           register: _delete_datasource
           failed_when: false
+          no_log: true
 
         - name: Delete embedding model deployment
           azure.azcollection.azure_rm_resource:

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -282,11 +282,13 @@
             method: POST
           register: _search_keys
           no_log: true
+          ignore_errors: true
 
         - name: Set search admin key fact
           ansible.builtin.set_fact:
             _search_admin_key: "{{ _search_keys.response.primaryKey }}"
           no_log: true
+          when: _search_keys is succeeded
 
         - name: Delete search indexer
           ansible.builtin.uri:
@@ -295,6 +297,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
+          when: _search_keys is succeeded
           ignore_errors: true
 
         - name: Delete search skillset
@@ -304,6 +307,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
+          when: _search_keys is succeeded
           ignore_errors: true
 
         - name: Delete search index
@@ -313,6 +317,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
+          when: _search_keys is succeeded
           ignore_errors: true
 
         - name: Delete search data source
@@ -322,6 +327,7 @@
             headers:
               api-key: "{{ _search_admin_key }}"
             status_code: [200, 204, 404]
+          when: _search_keys is succeeded
           ignore_errors: true
 
         - name: Delete embedding model deployment

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -108,148 +108,154 @@
         - name: Set storage connection string fact
           ansible.builtin.set_fact:
             _storage_connection_string: "{{ _storage_info.storageaccounts[0].primary_endpoints.blob.connectionstring }}"
+          no_log: true
+
+        - name: Retrieve AI Search admin key
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: listAdminKeys
+            api_version: "2023-11-01"
+            method: POST
+          register: _search_keys
+          no_log: true
+
+        - name: Set search admin key fact
+          ansible.builtin.set_fact:
+            _search_admin_key: "{{ _search_keys.response.primaryKey }}"
+          no_log: true
 
         - name: Create search data source
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: dataSources
-                name: "{{ azure_ai_search_datasource_name }}"
-            api_version: "2024-07-01"
-            idempotency: true
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/datasources/{{ azure_ai_search_datasource_name }}?api-version=2024-07-01"
+            method: PUT
+            headers:
+              Content-Type: application/json
+              api-key: "{{ _search_admin_key }}"
+            body_format: json
             body:
-              properties:
-                type: azureblob
-                credentials:
-                  connectionString: "{{ _storage_connection_string }}"
-                container:
-                  name: "{{ azure_storage_container_name }}"
+              name: "{{ azure_ai_search_datasource_name }}"
+              type: azureblob
+              credentials:
+                connectionString: "{{ _storage_connection_string }}"
+              container:
+                name: "{{ azure_storage_container_name }}"
+            status_code: [200, 201]
+          no_log: true
 
         - name: Create search index
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: indexes
-                name: "{{ azure_ai_search_index_name }}"
-            api_version: "2024-07-01"
-            idempotency: true
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/indexes/{{ azure_ai_search_index_name }}?api-version=2024-07-01"
+            method: PUT
+            headers:
+              Content-Type: application/json
+              api-key: "{{ _search_admin_key }}"
+            body_format: json
             body:
-              properties:
-                fields:
-                  - name: id
-                    type: Edm.String
-                    key: true
-                    filterable: true
-                  - name: content
-                    type: Edm.String
-                    searchable: true
-                    retrievable: true
-                  - name: title
-                    type: Edm.String
-                    searchable: true
-                    retrievable: true
-                    filterable: true
-                  - name: content_vector
-                    type: Collection(Edm.Single)
-                    searchable: true
-                    retrievable: false
-                    dimensions: 1536
-                    vectorSearchProfile: vector-profile
-                vectorSearch:
-                  algorithms:
-                    - name: hnsw-algorithm
-                      kind: hnsw
-                      hnswParameters:
-                        metric: cosine
-                        m: 4
-                        efConstruction: 400
-                        efSearch: 500
-                  profiles:
-                    - name: vector-profile
-                      algorithmConfigurationName: hnsw-algorithm
-                semanticConfiguration:
-                  defaultConfiguration: semantic-config
-                  configurations:
-                    - name: semantic-config
-                      prioritizedFields:
-                        titleField:
-                          fieldName: title
-                        contentFields:
-                          - fieldName: content
+              name: "{{ azure_ai_search_index_name }}"
+              fields:
+                - name: id
+                  type: Edm.String
+                  key: true
+                  filterable: true
+                - name: content
+                  type: Edm.String
+                  searchable: true
+                  retrievable: true
+                - name: title
+                  type: Edm.String
+                  searchable: true
+                  retrievable: true
+                  filterable: true
+                - name: content_vector
+                  type: Collection(Edm.Single)
+                  searchable: true
+                  retrievable: false
+                  dimensions: 1536
+                  vectorSearchProfile: vector-profile
+              vectorSearch:
+                algorithms:
+                  - name: hnsw-algorithm
+                    kind: hnsw
+                    hnswParameters:
+                      metric: cosine
+                      m: 4
+                      efConstruction: 400
+                      efSearch: 500
+                profiles:
+                  - name: vector-profile
+                    algorithmConfigurationName: hnsw-algorithm
+              semantic:
+                defaultConfiguration: semantic-config
+                configurations:
+                  - name: semantic-config
+                    prioritizedFields:
+                      titleField:
+                        fieldName: title
+                      contentFields:
+                        - fieldName: content
+            status_code: [200, 201]
 
         - name: Create search skillset
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: skillsets
-                name: "{{ azure_ai_search_skillset_name }}"
-            api_version: "2024-07-01"
-            idempotency: true
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/skillsets/{{ azure_ai_search_skillset_name }}?api-version=2024-07-01"
+            method: PUT
+            headers:
+              Content-Type: application/json
+              api-key: "{{ _search_admin_key }}"
+            body_format: json
             body:
-              properties:
-                description: Skillset for generating embeddings via Azure OpenAI
-                skills:
-                  - "@odata.type": "#Microsoft.Skills.Custom.AmlSkill"
-                    name: embedding-skill
-                    description: Generates embeddings using Azure OpenAI
-                    context: /document
-                    uri: "https://{{ azure_openai_account_name }}.openai.azure.com/openai/deployments/{{ azure_openai_embedding_deployment_name }}/embeddings?api-version=2024-06-01"
-                    httpMethod: POST
-                    httpHeaders:
-                      Content-Type: application/json
-                    batchSize: 1
-                    inputs:
-                      - name: input
-                        source: /document/content
-                    outputs:
-                      - name: data
-                        targetName: content_vector
-                cognitiveServices:
-                  "@odata.type": "#Microsoft.Azure.Search.CognitiveServicesByKey"
-                  description: Azure OpenAI resource
-                  key: ""
+              name: "{{ azure_ai_search_skillset_name }}"
+              description: Skillset for generating embeddings via Azure OpenAI
+              skills:
+                - "@odata.type": "#Microsoft.Skills.Text.AzureOpenAIEmbeddingSkill"
+                  name: embedding-skill
+                  description: Generates embeddings using Azure OpenAI
+                  context: /document
+                  resourceUri: "https://{{ azure_openai_account_name }}.openai.azure.com"
+                  deploymentId: "{{ azure_openai_embedding_deployment_name }}"
+                  modelName: "{{ azure_openai_embedding_model }}"
+                  inputs:
+                    - name: text
+                      source: /document/content
+                  outputs:
+                    - name: embedding
+                      targetName: content_vector
+            status_code: [200, 201]
 
         - name: Create search indexer
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: indexers
-                name: "{{ azure_ai_search_indexer_name }}"
-            api_version: "2024-07-01"
-            idempotency: true
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/indexers/{{ azure_ai_search_indexer_name }}?api-version=2024-07-01"
+            method: PUT
+            headers:
+              Content-Type: application/json
+              api-key: "{{ _search_admin_key }}"
+            body_format: json
             body:
-              properties:
-                dataSourceName: "{{ azure_ai_search_datasource_name }}"
-                targetIndexName: "{{ azure_ai_search_index_name }}"
-                skillsetName: "{{ azure_ai_search_skillset_name }}"
-                schedule:
-                  interval: PT2H
-                parameters:
-                  configuration:
-                    dataToExtract: contentAndMetadata
-                    parsingMode: default
-                fieldMappings:
-                  - sourceFieldName: metadata_storage_path
-                    targetFieldName: id
-                    mappingFunction:
-                      name: base64Encode
-                  - sourceFieldName: metadata_storage_name
-                    targetFieldName: title
-                outputFieldMappings:
-                  - sourceFieldName: /document/content_vector
-                    targetFieldName: content_vector
+              name: "{{ azure_ai_search_indexer_name }}"
+              dataSourceName: "{{ azure_ai_search_datasource_name }}"
+              targetIndexName: "{{ azure_ai_search_index_name }}"
+              skillsetName: "{{ azure_ai_search_skillset_name }}"
+              schedule:
+                interval: PT2H
+              parameters:
+                configuration:
+                  dataToExtract: contentAndMetadata
+                  parsingMode: default
+              fieldMappings:
+                - sourceFieldName: metadata_storage_path
+                  targetFieldName: id
+                  mappingFunction:
+                    name: base64Encode
+                - sourceFieldName: metadata_storage_name
+                  targetFieldName: title
+              outputFieldMappings:
+                - sourceFieldName: /document/content_vector
+                  targetFieldName: content_vector
+            status_code: [200, 201]
 
         # Phase 4 - Output
         - name: Display RAG pipeline endpoints
@@ -264,56 +270,58 @@
     - name: Delete RAG pipeline infrastructure
       when: operation | default('create') == 'delete'
       block:
-        - name: Delete search indexer
+        - name: Retrieve AI Search admin key
           azure.azcollection.azure_rm_resource:
             resource_group: "{{ azure_resource_group }}"
             provider: Microsoft.Search
             resource_type: searchServices
             resource_name: "{{ azure_ai_search_name }}"
             subresource:
-              - type: indexers
-                name: "{{ azure_ai_search_indexer_name }}"
-            api_version: "2024-07-01"
-            state: absent
+              - type: listAdminKeys
+            api_version: "2023-11-01"
+            method: POST
+          register: _search_keys
+          no_log: true
+
+        - name: Set search admin key fact
+          ansible.builtin.set_fact:
+            _search_admin_key: "{{ _search_keys.response.primaryKey }}"
+          no_log: true
+
+        - name: Delete search indexer
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/indexers/{{ azure_ai_search_indexer_name }}?api-version=2024-07-01"
+            method: DELETE
+            headers:
+              api-key: "{{ _search_admin_key }}"
+            status_code: [200, 204, 404]
           ignore_errors: true
 
         - name: Delete search skillset
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: skillsets
-                name: "{{ azure_ai_search_skillset_name }}"
-            api_version: "2024-07-01"
-            state: absent
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/skillsets/{{ azure_ai_search_skillset_name }}?api-version=2024-07-01"
+            method: DELETE
+            headers:
+              api-key: "{{ _search_admin_key }}"
+            status_code: [200, 204, 404]
           ignore_errors: true
 
         - name: Delete search index
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: indexes
-                name: "{{ azure_ai_search_index_name }}"
-            api_version: "2024-07-01"
-            state: absent
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/indexes/{{ azure_ai_search_index_name }}?api-version=2024-07-01"
+            method: DELETE
+            headers:
+              api-key: "{{ _search_admin_key }}"
+            status_code: [200, 204, 404]
           ignore_errors: true
 
         - name: Delete search data source
-          azure.azcollection.azure_rm_resource:
-            resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
-            resource_type: searchServices
-            resource_name: "{{ azure_ai_search_name }}"
-            subresource:
-              - type: dataSources
-                name: "{{ azure_ai_search_datasource_name }}"
-            api_version: "2024-07-01"
-            state: absent
+          ansible.builtin.uri:
+            url: "https://{{ azure_ai_search_name }}.search.windows.net/datasources/{{ azure_ai_search_datasource_name }}?api-version=2024-07-01"
+            method: DELETE
+            headers:
+              api-key: "{{ _search_admin_key }}"
+            status_code: [200, 204, 404]
           ignore_errors: true
 
         - name: Delete embedding model deployment

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -1,0 +1,375 @@
+---
+- name: Deploy RAG pipeline with Azure AI Search and OpenAI
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - vars/rag_pipeline_vars.yml
+
+  tasks:
+    - name: Fail when azure_resource_group is not defined
+      ansible.builtin.fail:
+        msg: Azure Resource group must be defined as azure_resource_group
+      when: azure_resource_group is not defined
+
+    - name: Create RAG pipeline infrastructure
+      when: operation | default('create') == 'create'
+      block:
+        # Phase 1 - Infrastructure via roles
+        - name: Create resource group
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_resource_group
+          vars:
+            azure_manage_resource_group_operation: create
+            azure_manage_resource_group_name: "{{ azure_resource_group }}"
+            azure_manage_resource_group_region: "{{ azure_region }}"
+
+        - name: Create storage account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_storage_account
+          vars:
+            azure_manage_storage_account_operation: create
+            azure_manage_storage_account_name: "{{ azure_storage_account_name }}"
+            azure_manage_storage_account_resource_group: "{{ azure_resource_group }}"
+            azure_manage_storage_account_region: "{{ azure_region }}"
+            azure_manage_storage_account_container_name: "{{ azure_storage_container_name }}"
+
+        - name: Create AI Search service
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_ai_search
+          vars:
+            azure_manage_ai_search_operation: create
+            azure_manage_ai_search_name: "{{ azure_ai_search_name }}"
+            azure_manage_ai_search_resource_group: "{{ azure_resource_group }}"
+            azure_manage_ai_search_region: "{{ azure_region }}"
+            azure_manage_ai_search_sku: "{{ azure_ai_search_sku }}"
+
+        - name: Create OpenAI account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_cognitive_account
+          vars:
+            azure_manage_cognitive_account_operation: create
+            azure_manage_cognitive_account_name: "{{ azure_openai_account_name }}"
+            azure_manage_cognitive_account_resource_group: "{{ azure_resource_group }}"
+            azure_manage_cognitive_account_region: "{{ azure_region }}"
+            azure_manage_cognitive_account_kind: OpenAI
+
+        # Phase 2 - OpenAI Model Deployments
+        - name: Deploy embedding model
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: CognitiveServices
+            resource_type: accounts
+            resource_name: "{{ azure_openai_account_name }}"
+            subresource:
+              - type: deployments
+                name: "{{ azure_openai_embedding_deployment_name }}"
+            api_version: "2024-10-01"
+            idempotency: true
+            body:
+              sku:
+                name: Standard
+                capacity: "{{ azure_openai_embedding_capacity }}"
+              properties:
+                model:
+                  format: OpenAI
+                  name: "{{ azure_openai_embedding_model }}"
+                  version: "{{ azure_openai_embedding_model_version }}"
+
+        - name: Deploy chat model
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: CognitiveServices
+            resource_type: accounts
+            resource_name: "{{ azure_openai_account_name }}"
+            subresource:
+              - type: deployments
+                name: "{{ azure_openai_chat_deployment_name }}"
+            api_version: "2024-10-01"
+            idempotency: true
+            body:
+              sku:
+                name: Standard
+                capacity: "{{ azure_openai_chat_capacity }}"
+              properties:
+                model:
+                  format: OpenAI
+                  name: "{{ azure_openai_chat_model }}"
+                  version: "{{ azure_openai_chat_model_version }}"
+
+        # Phase 3 - AI Search Pipeline
+        - name: Retrieve storage account keys
+          azure.azcollection.azure_rm_storageaccount_info:
+            resource_group: "{{ azure_resource_group }}"
+            name: "{{ azure_storage_account_name }}"
+            show_connection_string: true
+          register: _storage_info
+
+        - name: Set storage connection string fact
+          ansible.builtin.set_fact:
+            _storage_connection_string: "{{ _storage_info.storageaccounts[0].primary_endpoints.blob.connectionstring }}"
+
+        - name: Create search data source
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: dataSources
+                name: "{{ azure_ai_search_datasource_name }}"
+            api_version: "2024-07-01"
+            idempotency: true
+            body:
+              properties:
+                type: azureblob
+                credentials:
+                  connectionString: "{{ _storage_connection_string }}"
+                container:
+                  name: "{{ azure_storage_container_name }}"
+
+        - name: Create search index
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: indexes
+                name: "{{ azure_ai_search_index_name }}"
+            api_version: "2024-07-01"
+            idempotency: true
+            body:
+              properties:
+                fields:
+                  - name: id
+                    type: Edm.String
+                    key: true
+                    filterable: true
+                  - name: content
+                    type: Edm.String
+                    searchable: true
+                    retrievable: true
+                  - name: title
+                    type: Edm.String
+                    searchable: true
+                    retrievable: true
+                    filterable: true
+                  - name: content_vector
+                    type: Collection(Edm.Single)
+                    searchable: true
+                    retrievable: false
+                    dimensions: 1536
+                    vectorSearchProfile: vector-profile
+                vectorSearch:
+                  algorithms:
+                    - name: hnsw-algorithm
+                      kind: hnsw
+                      hnswParameters:
+                        metric: cosine
+                        m: 4
+                        efConstruction: 400
+                        efSearch: 500
+                  profiles:
+                    - name: vector-profile
+                      algorithmConfigurationName: hnsw-algorithm
+                semanticConfiguration:
+                  defaultConfiguration: semantic-config
+                  configurations:
+                    - name: semantic-config
+                      prioritizedFields:
+                        titleField:
+                          fieldName: title
+                        contentFields:
+                          - fieldName: content
+
+        - name: Create search skillset
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: skillsets
+                name: "{{ azure_ai_search_skillset_name }}"
+            api_version: "2024-07-01"
+            idempotency: true
+            body:
+              properties:
+                description: Skillset for generating embeddings via Azure OpenAI
+                skills:
+                  - "@odata.type": "#Microsoft.Skills.Custom.AmlSkill"
+                    name: embedding-skill
+                    description: Generates embeddings using Azure OpenAI
+                    context: /document
+                    uri: "https://{{ azure_openai_account_name }}.openai.azure.com/openai/deployments/{{ azure_openai_embedding_deployment_name }}/embeddings?api-version=2024-06-01"
+                    httpMethod: POST
+                    httpHeaders:
+                      Content-Type: application/json
+                    batchSize: 1
+                    inputs:
+                      - name: input
+                        source: /document/content
+                    outputs:
+                      - name: data
+                        targetName: content_vector
+                cognitiveServices:
+                  "@odata.type": "#Microsoft.Azure.Search.CognitiveServicesByKey"
+                  description: Azure OpenAI resource
+                  key: ""
+
+        - name: Create search indexer
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: indexers
+                name: "{{ azure_ai_search_indexer_name }}"
+            api_version: "2024-07-01"
+            idempotency: true
+            body:
+              properties:
+                dataSourceName: "{{ azure_ai_search_datasource_name }}"
+                targetIndexName: "{{ azure_ai_search_index_name }}"
+                skillsetName: "{{ azure_ai_search_skillset_name }}"
+                schedule:
+                  interval: PT2H
+                parameters:
+                  configuration:
+                    dataToExtract: contentAndMetadata
+                    parsingMode: default
+                fieldMappings:
+                  - sourceFieldName: metadata_storage_path
+                    targetFieldName: id
+                    mappingFunction:
+                      name: base64Encode
+                  - sourceFieldName: metadata_storage_name
+                    targetFieldName: title
+                outputFieldMappings:
+                  - sourceFieldName: /document/content_vector
+                    targetFieldName: content_vector
+
+        # Phase 4 - Output
+        - name: Display RAG pipeline endpoints
+          ansible.builtin.debug:
+            msg:
+              - "AI Search endpoint: https://{{ azure_ai_search_name }}.search.windows.net"
+              - "OpenAI endpoint: https://{{ azure_openai_account_name }}.openai.azure.com"
+              - "Embedding deployment: {{ azure_openai_embedding_deployment_name }}"
+              - "Chat deployment: {{ azure_openai_chat_deployment_name }}"
+              - "Search index: {{ azure_ai_search_index_name }}"
+
+    - name: Delete RAG pipeline infrastructure
+      when: operation | default('create') == 'delete'
+      block:
+        - name: Delete search indexer
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: indexers
+                name: "{{ azure_ai_search_indexer_name }}"
+            api_version: "2024-07-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete search skillset
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: skillsets
+                name: "{{ azure_ai_search_skillset_name }}"
+            api_version: "2024-07-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete search index
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: indexes
+                name: "{{ azure_ai_search_index_name }}"
+            api_version: "2024-07-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete search data source
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: Microsoft.Search
+            resource_type: searchServices
+            resource_name: "{{ azure_ai_search_name }}"
+            subresource:
+              - type: dataSources
+                name: "{{ azure_ai_search_datasource_name }}"
+            api_version: "2024-07-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete embedding model deployment
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: CognitiveServices
+            resource_type: accounts
+            resource_name: "{{ azure_openai_account_name }}"
+            subresource:
+              - type: deployments
+                name: "{{ azure_openai_embedding_deployment_name }}"
+            api_version: "2024-10-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete chat model deployment
+          azure.azcollection.azure_rm_resource:
+            resource_group: "{{ azure_resource_group }}"
+            provider: CognitiveServices
+            resource_type: accounts
+            resource_name: "{{ azure_openai_account_name }}"
+            subresource:
+              - type: deployments
+                name: "{{ azure_openai_chat_deployment_name }}"
+            api_version: "2024-10-01"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete OpenAI account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_cognitive_account
+          vars:
+            azure_manage_cognitive_account_operation: delete
+            azure_manage_cognitive_account_name: "{{ azure_openai_account_name }}"
+            azure_manage_cognitive_account_resource_group: "{{ azure_resource_group }}"
+
+        - name: Delete AI Search service
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_ai_search
+          vars:
+            azure_manage_ai_search_operation: delete
+            azure_manage_ai_search_name: "{{ azure_ai_search_name }}"
+            azure_manage_ai_search_resource_group: "{{ azure_resource_group }}"
+
+        - name: Delete storage account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_storage_account
+          vars:
+            azure_manage_storage_account_operation: delete
+            azure_manage_storage_account_name: "{{ azure_storage_account_name }}"
+            azure_manage_storage_account_resource_group: "{{ azure_resource_group }}"
+
+        - name: Delete resource group
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_resource_group
+          vars:
+            azure_manage_resource_group_operation: delete
+            azure_manage_resource_group_name: "{{ azure_resource_group }}"
+            azure_manage_resource_group_force_delete_nonempty: true

--- a/playbooks/rag_pipeline.yml
+++ b/playbooks/rag_pipeline.yml
@@ -113,7 +113,7 @@
         - name: Retrieve AI Search admin key
           azure.azcollection.azure_rm_resource:
             resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
+            provider: Search
             resource_type: searchServices
             resource_name: "{{ azure_ai_search_name }}"
             subresource:
@@ -143,7 +143,7 @@
                 connectionString: "{{ _storage_connection_string }}"
               container:
                 name: "{{ azure_storage_container_name }}"
-            status_code: [200, 201]
+            status_code: [200, 201, 204]
           no_log: true
 
         - name: Create search index
@@ -187,7 +187,7 @@
                       efSearch: 500
                 profiles:
                   - name: vector-profile
-                    algorithmConfigurationName: hnsw-algorithm
+                    algorithm: hnsw-algorithm
               semantic:
                 defaultConfiguration: semantic-config
                 configurations:
@@ -195,9 +195,9 @@
                     prioritizedFields:
                       titleField:
                         fieldName: title
-                      contentFields:
+                      prioritizedContentFields:
                         - fieldName: content
-            status_code: [200, 201]
+            status_code: [200, 201, 204]
 
         - name: Create search skillset
           ansible.builtin.uri:
@@ -224,7 +224,7 @@
                   outputs:
                     - name: embedding
                       targetName: content_vector
-            status_code: [200, 201]
+            status_code: [200, 201, 204]
 
         - name: Create search indexer
           ansible.builtin.uri:
@@ -255,7 +255,7 @@
               outputFieldMappings:
                 - sourceFieldName: /document/content_vector
                   targetFieldName: content_vector
-            status_code: [200, 201]
+            status_code: [200, 201, 204]
 
         # Phase 4 - Output
         - name: Display RAG pipeline endpoints
@@ -273,7 +273,7 @@
         - name: Retrieve AI Search admin key
           azure.azcollection.azure_rm_resource:
             resource_group: "{{ azure_resource_group }}"
-            provider: Microsoft.Search
+            provider: Search
             resource_type: searchServices
             resource_name: "{{ azure_ai_search_name }}"
             subresource:

--- a/playbooks/vars/rag_pipeline_vars.yml
+++ b/playbooks/vars/rag_pipeline_vars.yml
@@ -1,0 +1,28 @@
+---
+azure_region: eastus
+operation: create
+
+# Storage
+azure_storage_account_name: "{{ azure_resource_group | regex_replace('[^a-z0-9]', '') }}storage"
+azure_storage_container_name: documents
+
+# AI Search
+azure_ai_search_name: "{{ azure_resource_group }}-search"
+azure_ai_search_sku: basic
+
+# OpenAI
+azure_openai_account_name: "{{ azure_resource_group }}-openai"
+azure_openai_embedding_model: text-embedding-ada-002
+azure_openai_embedding_model_version: "2"
+azure_openai_embedding_deployment_name: embedding-deployment
+azure_openai_embedding_capacity: 1
+azure_openai_chat_model: gpt-4o
+azure_openai_chat_model_version: "2024-08-06"
+azure_openai_chat_deployment_name: chat-deployment
+azure_openai_chat_capacity: 1
+
+# Search Index
+azure_ai_search_index_name: rag-index
+azure_ai_search_datasource_name: rag-datasource
+azure_ai_search_indexer_name: rag-indexer
+azure_ai_search_skillset_name: rag-skillset

--- a/playbooks/vars/rag_pipeline_vars.yml
+++ b/playbooks/vars/rag_pipeline_vars.yml
@@ -17,7 +17,7 @@ azure_openai_embedding_model_version: "2"
 azure_openai_embedding_deployment_name: embedding-deployment
 azure_openai_embedding_capacity: 1
 azure_openai_chat_model: gpt-4o
-azure_openai_chat_model_version: "2024-08-06"
+azure_openai_chat_model_version: "2024-11-20"
 azure_openai_chat_deployment_name: chat-deployment
 azure_openai_chat_capacity: 1
 

--- a/roles/azure_configure_archost/meta/main.yml
+++ b/roles/azure_configure_archost/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_load_balancer_with_public_ip/meta/main.yml
+++ b/roles/azure_load_balancer_with_public_ip/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_ai_search/README.md
+++ b/roles/azure_manage_ai_search/README.md
@@ -1,0 +1,59 @@
+azure_manage_ai_search
+==============
+
+A role to manage Azure AI Search (formerly Cognitive Search) services. User can create or delete search services.
+
+Requirements
+------------
+
+* Azure User Account with valid permission
+* `azure.azcollection` >= 3.9.0
+
+Role Variables
+--------------
+
+* **azure_manage_ai_search_operation** - Operation to perform. Valid values are 'create', 'delete'. Default: **create**
+* **azure_manage_ai_search_name** - The name of the search service. Must be 2-60 characters, lowercase letters, digits, and dashes only, globally unique.
+* **azure_manage_ai_search_resource_group** - Resource group on/from which the search service will be created/deleted.
+* **azure_manage_ai_search_region** - An Azure location for the search service.
+* **azure_manage_ai_search_sku** - The pricing tier of the search service. Valid values are 'free', 'basic', 'standard', 'standard2', 'standard3', 'storage_optimized_l1', 'storage_optimized_l2'. Default: **basic**
+* **azure_manage_ai_search_replica_count** - The number of replicas in the search service (1-12 for standard, 1-3 for basic). Default: **1**
+* **azure_manage_ai_search_partition_count** - The number of partitions in the search service (1, 2, 3, 4, 6, or 12). Default: **1**
+* **azure_manage_ai_search_identity** - The managed identity type. Valid values are 'None', 'SystemAssigned'. Default: **SystemAssigned**
+* **azure_manage_ai_search_public_network_access** - Whether the search service is accessible from the public internet. Default: **enabled**
+* **azure_manage_ai_search_tags** - Dictionary of string:string pairs to assign as metadata to the object.
+
+Dependencies
+------------
+
+- NA
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      tasks:
+        - name: Create AI Search service
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_ai_search
+          vars:
+            azure_manage_ai_search_operation: create
+            azure_manage_ai_search_region: 'eastus'
+            azure_manage_ai_search_name: 'my-search-service'
+            azure_manage_ai_search_resource_group: 'resource-group'
+            azure_manage_ai_search_sku: 'basic'
+            azure_manage_ai_search_tags:
+              tag0: "tag0"
+              tag1: "tag1"
+
+License
+-------
+
+GNU General Public License v3.0 or later
+
+See [LICENCE](https://github.com/redhat-cop/cloud.azure_ops/blob/main/LICENSE) to see the full text.
+
+Author Information
+------------------
+
+- Ansible Cloud Content Team

--- a/roles/azure_manage_ai_search/defaults/main.yml
+++ b/roles/azure_manage_ai_search/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+azure_manage_ai_search_operation: create
+azure_manage_ai_search_sku: basic
+azure_manage_ai_search_replica_count: 1
+azure_manage_ai_search_partition_count: 1
+azure_manage_ai_search_identity: SystemAssigned
+azure_manage_ai_search_public_network_access: enabled

--- a/roles/azure_manage_ai_search/meta/argument_specs.yml
+++ b/roles/azure_manage_ai_search/meta/argument_specs.yml
@@ -1,0 +1,44 @@
+---
+argument_specs:
+  main:
+    version_added: 7.0.0
+    short_description: A role to manage Azure AI Search service.
+    description:
+      - A role to create or delete Azure AI Search (formerly Cognitive Search) services.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_ai_search_operation:
+        description: Operation to perform.
+        default: "create"
+        choices: ["create", "delete"]
+      azure_manage_ai_search_name:
+        description: The name of the search service. Must be 2-60 characters, lowercase letters, digits, and dashes only, globally unique.
+        required: true
+      azure_manage_ai_search_resource_group:
+        description: Resource group on/from which the search service will be created/deleted.
+        required: true
+      azure_manage_ai_search_region:
+        description: An Azure location for the search service.
+      azure_manage_ai_search_sku:
+        description: The pricing tier of the search service.
+        default: "basic"
+        choices: ["free", "basic", "standard", "standard2", "standard3", "storage_optimized_l1", "storage_optimized_l2"]
+      azure_manage_ai_search_replica_count:
+        description: The number of replicas in the search service.
+        type: int
+        default: 1
+      azure_manage_ai_search_partition_count:
+        description: The number of partitions in the search service.
+        type: int
+        default: 1
+      azure_manage_ai_search_identity:
+        description: The managed identity type for the search service.
+        default: "SystemAssigned"
+        choices: ["None", "SystemAssigned"]
+      azure_manage_ai_search_public_network_access:
+        description: Whether the search service is accessible from the public internet.
+        default: "enabled"
+        choices: ["enabled", "disabled"]
+      azure_manage_ai_search_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict

--- a/roles/azure_manage_ai_search/meta/main.yml
+++ b/roles/azure_manage_ai_search/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: Bill Peck
+  description: Role to manage Azure AI Search service.
+  company: Red Hat
+
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.15.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+
+  galaxy_tags:
+    - linux
+    - system
+    - ansible
+
+dependencies: []
+collections:
+  - azure.azcollection
+...

--- a/roles/azure_manage_ai_search/meta/main.yml
+++ b/roles/azure_manage_ai_search/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_ai_search/tasks/create.yml
+++ b/roles/azure_manage_ai_search/tasks/create.yml
@@ -1,0 +1,18 @@
+---
+- name: Check Region Setting
+  ansible.builtin.fail:
+    msg: Azure Region must be defined as azure_manage_ai_search_region
+  when: azure_manage_ai_search_region is not defined
+
+- name: Create AI Search service
+  azure.azcollection.azure_rm_cognitivesearch:
+    resource_group: "{{ azure_manage_ai_search_resource_group }}"
+    name: "{{ azure_manage_ai_search_name }}"
+    location: "{{ azure_manage_ai_search_region }}"
+    sku: "{{ azure_manage_ai_search_sku }}"
+    replica_count: "{{ azure_manage_ai_search_replica_count }}"
+    partition_count: "{{ azure_manage_ai_search_partition_count }}"
+    identity: "{{ azure_manage_ai_search_identity }}"
+    public_network_access: "{{ azure_manage_ai_search_public_network_access }}"
+    tags: "{{ azure_manage_ai_search_tags | default(omit) }}"
+  register: azure_manage_ai_search_result

--- a/roles/azure_manage_ai_search/tasks/delete.yml
+++ b/roles/azure_manage_ai_search/tasks/delete.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete AI Search service
+  azure.azcollection.azure_rm_cognitivesearch:
+    resource_group: "{{ azure_manage_ai_search_resource_group }}"
+    name: "{{ azure_manage_ai_search_name }}"
+    state: absent

--- a/roles/azure_manage_ai_search/tasks/main.yml
+++ b/roles/azure_manage_ai_search/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Create or delete AI Search service
+  ansible.builtin.include_tasks: "{{ azure_manage_ai_search_operation }}.yml"

--- a/roles/azure_manage_cognitive_account/README.md
+++ b/roles/azure_manage_cognitive_account/README.md
@@ -1,0 +1,57 @@
+azure_manage_cognitive_account
+==============
+
+A role to manage Azure Cognitive Services accounts (including Azure OpenAI). User can create or delete accounts.
+
+Requirements
+------------
+
+* Azure User Account with valid permission
+
+Role Variables
+--------------
+
+* **azure_manage_cognitive_account_operation** - Operation to perform. Valid values are 'create', 'delete'. Default: **create**
+* **azure_manage_cognitive_account_name** - The name of the Cognitive Services account.
+* **azure_manage_cognitive_account_resource_group** - Resource group on/from which the account will be created/deleted.
+* **azure_manage_cognitive_account_region** - An Azure location for the account.
+* **azure_manage_cognitive_account_kind** - The kind of Cognitive Services account (e.g., 'OpenAI', 'TextAnalytics', 'FormRecognizer'). Default: **OpenAI**
+* **azure_manage_cognitive_account_sku** - The pricing tier name. Default: **S0**
+* **azure_manage_cognitive_account_custom_subdomain** - Custom subdomain name for the account endpoint. Defaults to the account name.
+* **azure_manage_cognitive_account_public_network_access** - Whether the account is accessible from the public internet. Default: **Enabled**
+* **azure_manage_cognitive_account_tags** - Dictionary of string:string pairs to assign as metadata to the object.
+
+Dependencies
+------------
+
+- NA
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      tasks:
+        - name: Create Azure OpenAI account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_cognitive_account
+          vars:
+            azure_manage_cognitive_account_operation: create
+            azure_manage_cognitive_account_region: 'eastus'
+            azure_manage_cognitive_account_name: 'my-openai-account'
+            azure_manage_cognitive_account_resource_group: 'resource-group'
+            azure_manage_cognitive_account_kind: 'OpenAI'
+            azure_manage_cognitive_account_tags:
+              tag0: "tag0"
+              tag1: "tag1"
+
+License
+-------
+
+GNU General Public License v3.0 or later
+
+See [LICENCE](https://github.com/redhat-cop/cloud.azure_ops/blob/main/LICENSE) to see the full text.
+
+Author Information
+------------------
+
+- Ansible Cloud Content Team

--- a/roles/azure_manage_cognitive_account/README.md
+++ b/roles/azure_manage_cognitive_account/README.md
@@ -14,7 +14,7 @@ Role Variables
 * **azure_manage_cognitive_account_operation** - Operation to perform. Valid values are 'create', 'delete'. Default: **create**
 * **azure_manage_cognitive_account_name** - The name of the Cognitive Services account.
 * **azure_manage_cognitive_account_resource_group** - Resource group on/from which the account will be created/deleted.
-* **azure_manage_cognitive_account_region** - An Azure location for the account.
+* **azure_manage_cognitive_account_region** - An Azure location for the account. Defaults to the resource group location.
 * **azure_manage_cognitive_account_kind** - The kind of Cognitive Services account (e.g., 'OpenAI', 'TextAnalytics', 'FormRecognizer'). Default: **OpenAI**
 * **azure_manage_cognitive_account_sku** - The pricing tier name. Default: **S0**
 * **azure_manage_cognitive_account_custom_subdomain** - Custom subdomain name for the account endpoint. Defaults to the account name.

--- a/roles/azure_manage_cognitive_account/defaults/main.yml
+++ b/roles/azure_manage_cognitive_account/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+azure_manage_cognitive_account_operation: create
+azure_manage_cognitive_account_kind: OpenAI
+azure_manage_cognitive_account_sku: S0
+azure_manage_cognitive_account_public_network_access: Enabled

--- a/roles/azure_manage_cognitive_account/meta/argument_specs.yml
+++ b/roles/azure_manage_cognitive_account/meta/argument_specs.yml
@@ -1,0 +1,38 @@
+---
+argument_specs:
+  main:
+    version_added: 7.0.0
+    short_description: A role to manage Azure Cognitive Services accounts.
+    description:
+      - A role to create or delete Azure Cognitive Services accounts (including Azure OpenAI).
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_cognitive_account_operation:
+        description: Operation to perform.
+        default: "create"
+        choices: ["create", "delete"]
+      azure_manage_cognitive_account_name:
+        description: The name of the Cognitive Services account.
+        required: true
+      azure_manage_cognitive_account_resource_group:
+        description: Resource group on/from which the account will be created/deleted.
+        required: true
+      azure_manage_cognitive_account_region:
+        description: An Azure location for the account.
+      azure_manage_cognitive_account_kind:
+        description: The kind of Cognitive Services account.
+        default: "OpenAI"
+      azure_manage_cognitive_account_sku:
+        description: The pricing tier name.
+        default: "S0"
+      azure_manage_cognitive_account_custom_subdomain:
+        description:
+          - Custom subdomain name for the account endpoint.
+          - Defaults to the account name if not specified.
+      azure_manage_cognitive_account_public_network_access:
+        description: Whether the account is accessible from the public internet.
+        default: "Enabled"
+        choices: ["Enabled", "Disabled"]
+      azure_manage_cognitive_account_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict

--- a/roles/azure_manage_cognitive_account/meta/argument_specs.yml
+++ b/roles/azure_manage_cognitive_account/meta/argument_specs.yml
@@ -18,7 +18,9 @@ argument_specs:
         description: Resource group on/from which the account will be created/deleted.
         required: true
       azure_manage_cognitive_account_region:
-        description: An Azure location for the account.
+        description:
+          - An Azure location for the account.
+          - Defaults to the location of the resource group if not specified.
       azure_manage_cognitive_account_kind:
         description: The kind of Cognitive Services account.
         default: "OpenAI"

--- a/roles/azure_manage_cognitive_account/meta/main.yml
+++ b/roles/azure_manage_cognitive_account/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_cognitive_account/meta/main.yml
+++ b/roles/azure_manage_cognitive_account/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: Bill Peck
+  description: Role to manage Azure Cognitive Services accounts.
+  company: Red Hat
+
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.15.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+
+  galaxy_tags:
+    - linux
+    - system
+    - ansible
+
+dependencies: []
+collections:
+  - azure.azcollection
+...

--- a/roles/azure_manage_cognitive_account/tasks/create.yml
+++ b/roles/azure_manage_cognitive_account/tasks/create.yml
@@ -22,5 +22,5 @@
       properties:
         customSubDomainName: "{{ azure_manage_cognitive_account_custom_subdomain | default(azure_manage_cognitive_account_name) }}"
         publicNetworkAccess: "{{ azure_manage_cognitive_account_public_network_access }}"
-      tags: "{{ azure_manage_cognitive_account_tags | default({}) }}"
+      tags: "{{ azure_manage_cognitive_account_tags | default(omit) }}"
   register: azure_manage_cognitive_account_result

--- a/roles/azure_manage_cognitive_account/tasks/create.yml
+++ b/roles/azure_manage_cognitive_account/tasks/create.yml
@@ -1,26 +1,15 @@
 ---
-- name: Check Region Setting
-  ansible.builtin.fail:
-    msg: Azure Region must be defined as azure_manage_cognitive_account_region
-  when: azure_manage_cognitive_account_region is not defined
-
 - name: Create Cognitive Services account
-  azure.azcollection.azure_rm_resource:
+  azure.azcollection.azure_rm_cognitiveservicesaccount:
     resource_group: "{{ azure_manage_cognitive_account_resource_group }}"
-    provider: CognitiveServices
-    resource_type: accounts
-    resource_name: "{{ azure_manage_cognitive_account_name }}"
-    api_version: "2024-10-01"
-    idempotency: true
-    body:
-      kind: "{{ azure_manage_cognitive_account_kind }}"
-      location: "{{ azure_manage_cognitive_account_region }}"
-      sku:
-        name: "{{ azure_manage_cognitive_account_sku }}"
-      identity:
-        type: SystemAssigned
-      properties:
-        customSubDomainName: "{{ azure_manage_cognitive_account_custom_subdomain | default(azure_manage_cognitive_account_name) }}"
-        publicNetworkAccess: "{{ azure_manage_cognitive_account_public_network_access }}"
-      tags: "{{ azure_manage_cognitive_account_tags | default(omit) }}"
+    name: "{{ azure_manage_cognitive_account_name }}"
+    kind: "{{ azure_manage_cognitive_account_kind }}"
+    location: "{{ azure_manage_cognitive_account_region | default(omit) }}"
+    sku: "{{ azure_manage_cognitive_account_sku }}"
+    custom_domain_name: "{{ azure_manage_cognitive_account_custom_subdomain | default(azure_manage_cognitive_account_name) }}"
+    public_network_access: "{{ azure_manage_cognitive_account_public_network_access }}"
+    identity:
+      type: SystemAssigned
+    tags: "{{ azure_manage_cognitive_account_tags | default(omit) }}"
+    state: present
   register: azure_manage_cognitive_account_result

--- a/roles/azure_manage_cognitive_account/tasks/create.yml
+++ b/roles/azure_manage_cognitive_account/tasks/create.yml
@@ -1,0 +1,26 @@
+---
+- name: Check Region Setting
+  ansible.builtin.fail:
+    msg: Azure Region must be defined as azure_manage_cognitive_account_region
+  when: azure_manage_cognitive_account_region is not defined
+
+- name: Create Cognitive Services account
+  azure.azcollection.azure_rm_resource:
+    resource_group: "{{ azure_manage_cognitive_account_resource_group }}"
+    provider: CognitiveServices
+    resource_type: accounts
+    resource_name: "{{ azure_manage_cognitive_account_name }}"
+    api_version: "2024-10-01"
+    idempotency: true
+    body:
+      kind: "{{ azure_manage_cognitive_account_kind }}"
+      location: "{{ azure_manage_cognitive_account_region }}"
+      sku:
+        name: "{{ azure_manage_cognitive_account_sku }}"
+      identity:
+        type: SystemAssigned
+      properties:
+        customSubDomainName: "{{ azure_manage_cognitive_account_custom_subdomain | default(azure_manage_cognitive_account_name) }}"
+        publicNetworkAccess: "{{ azure_manage_cognitive_account_public_network_access }}"
+      tags: "{{ azure_manage_cognitive_account_tags | default({}) }}"
+  register: azure_manage_cognitive_account_result

--- a/roles/azure_manage_cognitive_account/tasks/delete.yml
+++ b/roles/azure_manage_cognitive_account/tasks/delete.yml
@@ -1,9 +1,6 @@
 ---
 - name: Delete Cognitive Services account
-  azure.azcollection.azure_rm_resource:
+  azure.azcollection.azure_rm_cognitiveservicesaccount:
     resource_group: "{{ azure_manage_cognitive_account_resource_group }}"
-    provider: CognitiveServices
-    resource_type: accounts
-    resource_name: "{{ azure_manage_cognitive_account_name }}"
-    api_version: "2024-10-01"
+    name: "{{ azure_manage_cognitive_account_name }}"
     state: absent

--- a/roles/azure_manage_cognitive_account/tasks/delete.yml
+++ b/roles/azure_manage_cognitive_account/tasks/delete.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete Cognitive Services account
+  azure.azcollection.azure_rm_resource:
+    resource_group: "{{ azure_manage_cognitive_account_resource_group }}"
+    provider: CognitiveServices
+    resource_type: accounts
+    resource_name: "{{ azure_manage_cognitive_account_name }}"
+    api_version: "2024-10-01"
+    state: absent

--- a/roles/azure_manage_cognitive_account/tasks/main.yml
+++ b/roles/azure_manage_cognitive_account/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Create or delete Cognitive Services account
+  ansible.builtin.include_tasks: "{{ azure_manage_cognitive_account_operation }}.yml"

--- a/roles/azure_manage_network_interface/meta/main.yml
+++ b/roles/azure_manage_network_interface/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_networking_stack/meta/main.yml
+++ b/roles/azure_manage_networking_stack/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_postgresqlflex/meta/main.yml
+++ b/roles/azure_manage_postgresqlflex/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_resource_group/meta/main.yml
+++ b/roles/azure_manage_resource_group/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_security_group/meta/main.yml
+++ b/roles/azure_manage_security_group/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_snapshot/meta/main.yml
+++ b/roles/azure_manage_snapshot/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_storage_account/README.md
+++ b/roles/azure_manage_storage_account/README.md
@@ -1,0 +1,57 @@
+azure_manage_storage_account
+==============
+
+A role to manage Azure Storage Accounts. User can create or delete storage accounts with optional blob container creation.
+
+Requirements
+------------
+
+* Azure User Account with valid permission
+
+Role Variables
+--------------
+
+* **azure_manage_storage_account_operation** - Operation to perform. Valid values are 'create', 'delete'. Default: **create**
+* **azure_manage_storage_account_name** - The name of the storage account. Must be 3-24 characters, lowercase letters and numbers only.
+* **azure_manage_storage_account_resource_group** - Resource group on/from which the storage account will be created/deleted.
+* **azure_manage_storage_account_region** - An Azure location for the storage account.
+* **azure_manage_storage_account_kind** - The kind of storage account. Default: **StorageV2**
+* **azure_manage_storage_account_sku** - The storage account replication type. Default: **Standard_LRS**
+* **azure_manage_storage_account_access_tier** - The access tier for BlobStorage and StorageV2 accounts. Default: **Hot**
+* **azure_manage_storage_account_container_name** - Name of blob container to create. Omit to skip container creation.
+* **azure_manage_storage_account_tags** - Dictionary of string:string pairs to assign as metadata to the object.
+
+Dependencies
+------------
+
+- NA
+
+Example Playbook
+----------------
+
+    - hosts: localhost
+      tasks:
+        - name: Create Storage Account
+          ansible.builtin.include_role:
+            name: cloud.azure_ops.azure_manage_storage_account
+          vars:
+            azure_manage_storage_account_operation: create
+            azure_manage_storage_account_region: 'eastus'
+            azure_manage_storage_account_name: 'mystorageaccount'
+            azure_manage_storage_account_resource_group: 'resource-group'
+            azure_manage_storage_account_container_name: 'documents'
+            azure_manage_storage_account_tags:
+              tag0: "tag0"
+              tag1: "tag1"
+
+License
+-------
+
+GNU General Public License v3.0 or later
+
+See [LICENCE](https://github.com/redhat-cop/cloud.azure_ops/blob/main/LICENSE) to see the full text.
+
+Author Information
+------------------
+
+- Ansible Cloud Content Team

--- a/roles/azure_manage_storage_account/defaults/main.yml
+++ b/roles/azure_manage_storage_account/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+azure_manage_storage_account_operation: create
+azure_manage_storage_account_kind: StorageV2
+azure_manage_storage_account_sku: Standard_LRS
+azure_manage_storage_account_access_tier: Hot

--- a/roles/azure_manage_storage_account/meta/argument_specs.yml
+++ b/roles/azure_manage_storage_account/meta/argument_specs.yml
@@ -1,0 +1,38 @@
+---
+argument_specs:
+  main:
+    version_added: 7.0.0
+    short_description: A role to manage Azure Storage Accounts.
+    description:
+      - A role to create or delete Azure Storage Accounts with optional blob container.
+      - This role requires an azure user account with valid permission.
+    options:
+      azure_manage_storage_account_operation:
+        description: Operation to perform.
+        default: "create"
+        choices: ["create", "delete"]
+      azure_manage_storage_account_name:
+        description: The name of the storage account. Must be 3-24 characters, lowercase letters and numbers only.
+        required: true
+      azure_manage_storage_account_resource_group:
+        description: Resource group on/from which the storage account will be created/deleted.
+        required: true
+      azure_manage_storage_account_region:
+        description: An Azure location for the storage account.
+      azure_manage_storage_account_kind:
+        description: The kind of storage account.
+        default: "StorageV2"
+        choices: ["Storage", "StorageV2", "BlobStorage", "BlockBlobStorage", "FileStorage"]
+      azure_manage_storage_account_sku:
+        description: The storage account replication type.
+        default: "Standard_LRS"
+        choices: ["Standard_LRS", "Standard_GRS", "Standard_RAGRS", "Standard_ZRS", "Premium_LRS", "Premium_ZRS"]
+      azure_manage_storage_account_access_tier:
+        description: The access tier for BlobStorage and StorageV2 accounts.
+        default: "Hot"
+        choices: ["Hot", "Cool"]
+      azure_manage_storage_account_container_name:
+        description: Name of blob container to create. Omit to skip container creation.
+      azure_manage_storage_account_tags:
+        description: Dictionary of string:string pairs to assign as metadata to the object.
+        type: dict

--- a/roles/azure_manage_storage_account/meta/main.yml
+++ b/roles/azure_manage_storage_account/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  author: Bill Peck
+  description: Role to manage Azure Storage Account.
+  company: Red Hat
+
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.15.0
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+
+  galaxy_tags:
+    - linux
+    - system
+    - ansible
+
+dependencies: []
+collections:
+  - azure.azcollection
+...

--- a/roles/azure_manage_storage_account/meta/main.yml
+++ b/roles/azure_manage_storage_account/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_manage_storage_account/tasks/create.yml
+++ b/roles/azure_manage_storage_account/tasks/create.yml
@@ -1,0 +1,34 @@
+---
+- name: Check Region Setting
+  ansible.builtin.fail:
+    msg: Azure Region must be defined as azure_manage_storage_account_region
+  when: azure_manage_storage_account_region is not defined
+
+- name: Create storage account
+  azure.azcollection.azure_rm_storageaccount:
+    resource_group: "{{ azure_manage_storage_account_resource_group }}"
+    name: "{{ azure_manage_storage_account_name }}"
+    location: "{{ azure_manage_storage_account_region }}"
+    account_type: "{{ azure_manage_storage_account_sku }}"
+    kind: "{{ azure_manage_storage_account_kind }}"
+    access_tier: "{{ azure_manage_storage_account_access_tier }}"
+    tags: "{{ azure_manage_storage_account_tags | default(omit) }}"
+  register: azure_manage_storage_account_result
+
+- name: Create blob container
+  azure.azcollection.azure_rm_resource:
+    resource_group: "{{ azure_manage_storage_account_resource_group }}"
+    provider: Microsoft.Storage
+    resource_type: storageAccounts
+    resource_name: "{{ azure_manage_storage_account_name }}"
+    subresource:
+      - type: blobServices
+        name: default
+      - type: containers
+        name: "{{ azure_manage_storage_account_container_name }}"
+    api_version: "2023-05-01"
+    body:
+      properties:
+        publicAccess: None
+    idempotency: true
+  when: azure_manage_storage_account_container_name is defined

--- a/roles/azure_manage_storage_account/tasks/create.yml
+++ b/roles/azure_manage_storage_account/tasks/create.yml
@@ -18,7 +18,7 @@
 - name: Create blob container
   azure.azcollection.azure_rm_resource:
     resource_group: "{{ azure_manage_storage_account_resource_group }}"
-    provider: Microsoft.Storage
+    provider: Storage
     resource_type: storageAccounts
     resource_name: "{{ azure_manage_storage_account_name }}"
     subresource:

--- a/roles/azure_manage_storage_account/tasks/delete.yml
+++ b/roles/azure_manage_storage_account/tasks/delete.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete storage account
+  azure.azcollection.azure_rm_storageaccount:
+    resource_group: "{{ azure_manage_storage_account_resource_group }}"
+    name: "{{ azure_manage_storage_account_name }}"
+    state: absent

--- a/roles/azure_manage_storage_account/tasks/delete.yml
+++ b/roles/azure_manage_storage_account/tasks/delete.yml
@@ -4,3 +4,4 @@
     resource_group: "{{ azure_manage_storage_account_resource_group }}"
     name: "{{ azure_manage_storage_account_name }}"
     state: absent
+    force_delete_nonempty: true

--- a/roles/azure_manage_storage_account/tasks/main.yml
+++ b/roles/azure_manage_storage_account/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Create or delete storage account
+  ansible.builtin.include_tasks: "{{ azure_manage_storage_account_operation }}.yml"

--- a/roles/azure_repo_microsoft_prod/meta/main.yml
+++ b/roles/azure_repo_microsoft_prod/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/roles/azure_virtual_machine_with_public_ip/meta/main.yml
+++ b/roles/azure_virtual_machine_with_public_ip/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
+        - "10"
 
   galaxy_tags:
     - linux

--- a/tests/integration/targets/azure_ops_test_azure_manage_ai_search/aliases
+++ b/tests/integration/targets/azure_ops_test_azure_manage_ai_search/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+role/azure_manage_ai_search
+time=2m

--- a/tests/integration/targets/azure_ops_test_azure_manage_ai_search/defaults/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_ai_search/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+azure_manage_ai_search_name: "{{ resource_prefix }}-aisearch"
+azure_manage_ai_search_sku: basic
+azure_manage_ai_search_replica_count: 1
+azure_manage_ai_search_partition_count: 1
+azure_manage_ai_search_identity: SystemAssigned
+azure_manage_ai_search_public_network_access: enabled
+azure_manage_ai_search_tags:
+  resource_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/azure_ops_test_azure_manage_ai_search/tasks/create_and_delete_ai_search.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_ai_search/tasks/create_and_delete_ai_search.yml
@@ -1,0 +1,68 @@
+---
+- name: Test Create and Delete AI Search service
+  block:
+    - name: Print test step details
+      ansible.builtin.debug:
+        msg: "Run test with resource_group={{ test_resource_group }}"
+
+    # Test: Create AI Search service
+    - name: Create AI Search service
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_ai_search
+      vars:
+        azure_manage_ai_search_operation: create
+        azure_manage_ai_search_resource_group: "{{ test_resource_group }}"
+
+    # Verify AI Search service was created
+    - name: Gather AI Search service info
+      azure.azcollection.azure_rm_cognitivesearch_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_ai_search_name }}"
+      register: _ai_search
+
+    - name: Assert that AI Search service was created as expected
+      ansible.builtin.assert:
+        that:
+          - _ai_search.search | length == 1
+          - _ai_search.search[0].name == azure_manage_ai_search_name
+          - _ai_search.search[0].sku == azure_manage_ai_search_sku
+          - _ai_search.search[0].replica_count == azure_manage_ai_search_replica_count
+          - _ai_search.search[0].partition_count == azure_manage_ai_search_partition_count
+
+    # Test: Create AI Search service again (idempotency)
+    - name: Create AI Search service again (idempotency check)
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_ai_search
+      vars:
+        azure_manage_ai_search_operation: create
+        azure_manage_ai_search_resource_group: "{{ test_resource_group }}"
+
+    - name: Gather AI Search service info after idempotency check
+      azure.azcollection.azure_rm_cognitivesearch_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_ai_search_name }}"
+      register: _ai_search_idem
+
+    - name: Assert that AI Search service still exists after idempotent create
+      ansible.builtin.assert:
+        that:
+          - _ai_search_idem.search | length == 1
+          - _ai_search_idem.search[0].name == azure_manage_ai_search_name
+
+    # Test: Delete AI Search service
+    - name: Delete AI Search service
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_ai_search
+      vars:
+        azure_manage_ai_search_operation: delete
+        azure_manage_ai_search_resource_group: "{{ test_resource_group }}"
+
+    # Verify AI Search service was deleted
+    - name: Ensure AI Search service was deleted
+      azure.azcollection.azure_rm_cognitivesearch_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_ai_search_name }}"
+      register: _ai_search
+      until: _ai_search.search | length == 0
+      retries: 10
+      delay: 10

--- a/tests/integration/targets/azure_ops_test_azure_manage_ai_search/tasks/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_ai_search/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Determine Azure Region
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Test role cloud.azure_ops.azure_manage_ai_search
+  block:
+    - name: Run create and delete tests
+      ansible.builtin.include_tasks: create_and_delete_ai_search.yml
+      vars:
+        test_resource_group: "{{ resource_group }}"
+        azure_manage_ai_search_region: "{{ __rg_info.resourcegroups.0.location }}"
+
+  always:
+    - name: Cleanup - Delete AI Search service
+      azure.azcollection.azure_rm_cognitivesearch:
+        resource_group: "{{ resource_group }}"
+        name: "{{ azure_manage_ai_search_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/aliases
+++ b/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+role/azure_manage_cognitive_account
+time=2m

--- a/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/defaults/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+azure_manage_cognitive_account_name: "{{ resource_prefix }}-cogacct"
+azure_manage_cognitive_account_kind: OpenAI
+azure_manage_cognitive_account_sku: S0
+azure_manage_cognitive_account_public_network_access: Enabled
+azure_manage_cognitive_account_tags:
+  resource_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/tasks/create_and_delete_cognitive_account.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/tasks/create_and_delete_cognitive_account.yml
@@ -1,0 +1,67 @@
+---
+- name: Test Create and Delete Cognitive Services account
+  block:
+    - name: Print test step details
+      ansible.builtin.debug:
+        msg: "Run test with resource_group={{ test_resource_group }}"
+
+    # Test: Create Cognitive Services account
+    - name: Create Cognitive Services account
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_cognitive_account
+      vars:
+        azure_manage_cognitive_account_operation: create
+        azure_manage_cognitive_account_resource_group: "{{ test_resource_group }}"
+
+    # Verify Cognitive Services account was created
+    - name: Gather Cognitive Services account info
+      azure.azcollection.azure_rm_cognitiveservicesaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_cognitive_account_name }}"
+      register: _cognitive_account
+
+    - name: Assert that Cognitive Services account was created as expected
+      ansible.builtin.assert:
+        that:
+          - _cognitive_account.accounts | length == 1
+          - _cognitive_account.accounts[0].name == azure_manage_cognitive_account_name
+          - _cognitive_account.accounts[0].kind == azure_manage_cognitive_account_kind
+          - _cognitive_account.accounts[0].sku.name == azure_manage_cognitive_account_sku
+
+    # Test: Create Cognitive Services account again (idempotency)
+    - name: Create Cognitive Services account again (idempotency check)
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_cognitive_account
+      vars:
+        azure_manage_cognitive_account_operation: create
+        azure_manage_cognitive_account_resource_group: "{{ test_resource_group }}"
+
+    - name: Gather Cognitive Services account info after idempotency check
+      azure.azcollection.azure_rm_cognitiveservicesaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_cognitive_account_name }}"
+      register: _cognitive_account_idem
+
+    - name: Assert that Cognitive Services account still exists after idempotent create
+      ansible.builtin.assert:
+        that:
+          - _cognitive_account_idem.accounts | length == 1
+          - _cognitive_account_idem.accounts[0].name == azure_manage_cognitive_account_name
+
+    # Test: Delete Cognitive Services account
+    - name: Delete Cognitive Services account
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_cognitive_account
+      vars:
+        azure_manage_cognitive_account_operation: delete
+        azure_manage_cognitive_account_resource_group: "{{ test_resource_group }}"
+
+    # Verify Cognitive Services account was deleted
+    - name: Ensure Cognitive Services account was deleted
+      azure.azcollection.azure_rm_cognitiveservicesaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_cognitive_account_name }}"
+      register: _cognitive_account
+      until: _cognitive_account.accounts | length == 0
+      retries: 10
+      delay: 10

--- a/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/tasks/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_cognitive_account/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Test role cloud.azure_ops.azure_manage_cognitive_account
+  block:
+    - name: Run create and delete tests
+      ansible.builtin.include_tasks: create_and_delete_cognitive_account.yml
+      vars:
+        test_resource_group: "{{ resource_group }}"
+        azure_manage_cognitive_account_region: "{{ __rg_info.resourcegroups.0.location }}"
+
+  always:
+    - name: Cleanup - Delete Cognitive Services account
+      azure.azcollection.azure_rm_cognitiveservicesaccount:
+        resource_group: "{{ resource_group }}"
+        name: "{{ azure_manage_cognitive_account_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/azure_ops_test_azure_manage_storage_account/aliases
+++ b/tests/integration/targets/azure_ops_test_azure_manage_storage_account/aliases
@@ -1,0 +1,3 @@
+cloud/azure
+role/azure_manage_storage_account
+time=2m

--- a/tests/integration/targets/azure_ops_test_azure_manage_storage_account/defaults/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_storage_account/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+azure_manage_storage_account_name: "{{ resource_prefix | replace('-', '') | truncate(24, true, '') }}"
+azure_manage_storage_account_kind: StorageV2
+azure_manage_storage_account_sku: Standard_LRS
+azure_manage_storage_account_access_tier: Hot
+azure_manage_storage_account_container_name: testcontainer
+azure_manage_storage_account_tags:
+  resource_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/azure_ops_test_azure_manage_storage_account/tasks/create_and_delete_storage_account.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_storage_account/tasks/create_and_delete_storage_account.yml
@@ -1,0 +1,115 @@
+---
+- name: Test Create and Delete Storage Account
+  block:
+    - name: Print test step details
+      ansible.builtin.debug:
+        msg: "Run test with resource_group={{ test_resource_group }}"
+
+    # Test: Create storage account with blob container
+    - name: Create storage account with blob container
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_storage_account
+      vars:
+        azure_manage_storage_account_operation: create
+        azure_manage_storage_account_resource_group: "{{ test_resource_group }}"
+
+    # Verify storage account was created
+    - name: Gather storage account info
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+      register: _storage_account
+
+    - name: Assert that storage account was created as expected
+      ansible.builtin.assert:
+        that:
+          - _storage_account.storageaccounts | length == 1
+          - _storage_account.storageaccounts[0].name == azure_manage_storage_account_name
+          - _storage_account.storageaccounts[0].account_type == azure_manage_storage_account_sku
+          - _storage_account.storageaccounts[0].kind == azure_manage_storage_account_kind
+
+    # Verify blob container was created
+    - name: Gather blob container info
+      azure.azcollection.azure_rm_resource_info:
+        resource_group: "{{ test_resource_group }}"
+        provider: Microsoft.Storage
+        resource_type: storageAccounts
+        resource_name: "{{ azure_manage_storage_account_name }}"
+        subresource:
+          - type: blobServices
+            name: default
+          - type: containers
+            name: "{{ azure_manage_storage_account_container_name }}"
+        api_version: "2023-05-01"
+      register: _blob_container
+
+    - name: Assert that blob container was created
+      ansible.builtin.assert:
+        that:
+          - _blob_container.response | length == 1
+          - _blob_container.response[0].name == azure_manage_storage_account_container_name
+
+    # Test: Create storage account again (idempotency)
+    - name: Create storage account again (idempotency check)
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_storage_account
+      vars:
+        azure_manage_storage_account_operation: create
+        azure_manage_storage_account_resource_group: "{{ test_resource_group }}"
+
+    - name: Gather storage account info after idempotency check
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+      register: _storage_account_idem
+
+    - name: Assert that storage account still exists after idempotent create
+      ansible.builtin.assert:
+        that:
+          - _storage_account_idem.storageaccounts | length == 1
+          - _storage_account_idem.storageaccounts[0].name == azure_manage_storage_account_name
+
+    # Test: Create storage account without container
+    - name: Delete storage account before no-container test
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+        state: absent
+
+    - name: Create storage account without blob container
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_storage_account
+      vars:
+        azure_manage_storage_account_operation: create
+        azure_manage_storage_account_resource_group: "{{ test_resource_group }}"
+        azure_manage_storage_account_container_name: "{{ omit }}"
+
+    - name: Gather storage account info after no-container create
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+      register: _storage_account_no_container
+
+    - name: Assert that storage account was created without container
+      ansible.builtin.assert:
+        that:
+          - _storage_account_no_container.storageaccounts | length == 1
+          - _storage_account_no_container.storageaccounts[0].name == azure_manage_storage_account_name
+
+    # Test: Delete storage account
+    - name: Delete storage account
+      ansible.builtin.include_role:
+        name: cloud.azure_ops.azure_manage_storage_account
+      vars:
+        azure_manage_storage_account_operation: delete
+        azure_manage_storage_account_resource_group: "{{ test_resource_group }}"
+
+    # Verify storage account was deleted
+    - name: Ensure storage account was deleted
+      azure.azcollection.azure_rm_storageaccount_info:
+        resource_group: "{{ test_resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+      register: _storage_account
+      until: _storage_account.storageaccounts | length == 0
+      retries: 10
+      delay: 5

--- a/tests/integration/targets/azure_ops_test_azure_manage_storage_account/tasks/main.yml
+++ b/tests/integration/targets/azure_ops_test_azure_manage_storage_account/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Determine Azure Region
+- name: Gather Resource Group info
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name: "{{ resource_group }}"
+  register: __rg_info
+
+- name: Test role cloud.azure_ops.azure_manage_storage_account
+  block:
+    - name: Run create and delete tests
+      ansible.builtin.include_tasks: create_and_delete_storage_account.yml
+      vars:
+        test_resource_group: "{{ resource_group }}"
+        azure_manage_storage_account_region: "{{ __rg_info.resourcegroups.0.location }}"
+
+  always:
+    - name: Cleanup - Delete storage account
+      azure.azcollection.azure_rm_storageaccount:
+        resource_group: "{{ resource_group }}"
+        name: "{{ azure_manage_storage_account_name }}"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
## Summary

- Adds 3 new roles (`azure_manage_storage_account`, `azure_manage_ai_search`, `azure_manage_cognitive_account`) and a `rag_pipeline.yml` playbook implementing a complete RAG (Retrieval-Augmented Generation) pipeline on Azure
- Provisions Azure Storage (with blob container), AI Search service, OpenAI account with embedding and chat model deployments, and configures the search data-plane pipeline (data source, index, skillset with `AzureOpenAIEmbeddingSkill`, indexer)
- Supports both `create` and `delete` operations with resilient teardown ordering
- Bumps `azure.azcollection` dependency to `>=3.9.0` for `azure_rm_cognitivesearch` module support

Resolves: [ACA-5885](https://redhat.atlassian.net/browse/ACA-5885)

## Details

### New Roles
| Role | Module | Purpose |
|------|--------|---------|
| `azure_manage_storage_account` | `azure_rm_storageaccount` | Storage account + optional blob container |
| `azure_manage_ai_search` | `azure_rm_cognitivesearch` | Azure AI Search service |
| `azure_manage_cognitive_account` | `azure_rm_resource` | Cognitive Services / OpenAI accounts |

### Playbook Architecture
```
Blob Storage (documents)
       │
       ▼
AI Search Indexer ──▶ Skillset (OpenAI embeddings)
       │
       ▼
AI Search Index ◀── Query via Azure OpenAI (chat model)
```

Search data-plane resources (data sources, indexes, skillsets, indexers) use `ansible.builtin.uri` against the search REST API since these are not ARM-managed resources.

## Test plan
- [ ] Verify `yamllint` passes on all new YAML files
- [ ] Run `ansible-playbook playbooks/rag_pipeline.yml` with `operation=create` against a test subscription
- [ ] Verify all resources are provisioned (storage, AI Search, OpenAI, model deployments, search pipeline)
- [ ] Run with `operation=delete` and verify clean teardown
- [ ] Test partial delete (e.g., search service already removed) to verify resilient delete block

🤖 Generated with [Claude Code](https://claude.com/claude-code)